### PR TITLE
[wip #13] cleanup observer mode implementation [skip ci]

### DIFF
--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -876,7 +876,10 @@ namespace Glest
 
           if (openNetworkSlots == true)
           {
-            for (int i = 1; i < mapInfo.players; ++i)
+            int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+            for (int i = 1; i < maxSlots; ++i)
             {
               listBoxControls[i].setSelectedItemIndex (ctNetwork);
             }
@@ -2130,7 +2133,10 @@ namespace Glest
           }
           else
           {
-            for (int i = 0; i < mapInfo.players; ++i)
+            int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+            for (int i = 0; i < maxSlots; ++i)
             {
               MutexSafeWrapper
                 safeMutex ((publishToMasterserverThread !=
@@ -2197,7 +2203,7 @@ namespace Glest
                     && currentControlType != ctHuman)
                 {
                   slotsToChangeStart = 0;
-                  slotsToChangeEnd = mapInfo.players - 1;
+                  slotsToChangeEnd = maxSlots - 1;
                 }
 
                 for (int index = slotsToChangeStart;
@@ -2655,7 +2661,11 @@ namespace Glest
         NetworkManager::getInstance ().getServerInterface ();
 
       bool dataSynchCheckOk = true;
-      for (int i = 0; i < mapInfo.players; ++i)
+
+      int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+      for (int i = 0; i < maxSlots; ++i)
       {
         if (listBoxControls[i].getSelectedItemIndex () == ctNetwork)
         {
@@ -2741,6 +2751,7 @@ namespace Glest
 
       std::vector < string > randomFactionSelectionList;
       int RandomCount = 0;
+
       for (int i = 0; i < mapInfo.players; ++i)
       {
         if (SystemFlags::
@@ -2996,7 +3007,11 @@ namespace Glest
         if (isMasterserverMode () == false)
         {
           bool hasHuman = false;
-          for (int i = 0; i < mapInfo.players; ++i)
+
+          int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+          for (int i = 0; i < maxSlots; ++i)
           {
             if (SystemFlags::getSystemSettingType (SystemFlags::debugSystem).
                 enabled)
@@ -3554,8 +3569,11 @@ namespace Glest
               && listBoxControls[i].getSelectedItemIndex () !=
               ctNetworkUnassigned)
           {
-            if (i < mapInfo.players
-                || (i >= mapInfo.players
+            int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+            if (i < maxSlots
+                || (i >= maxSlots
                     && listBoxControls[i].getSelectedItemIndex () !=
                     ctNetwork))
             {
@@ -3637,18 +3655,21 @@ namespace Glest
                     listBoxControls[switchFactionIdx].setSelectedItemIndex
                       (ctClosed);
 
+                    int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
                     labelPlayers[switchFactionIdx].setVisible
-                      (switchFactionIdx + 1 <= mapInfo.players);
+                      (switchFactionIdx + 1 <= maxSlots);
                     labelPlayerNames[switchFactionIdx].setVisible
-                      (switchFactionIdx + 1 <= mapInfo.players);
+                      (switchFactionIdx + 1 <= maxSlots);
                     listBoxControls[switchFactionIdx].setVisible
-                      (switchFactionIdx + 1 <= mapInfo.players);
+                      (switchFactionIdx + 1 <= maxSlots);
                     listBoxFactions[switchFactionIdx].setVisible
-                      (switchFactionIdx + 1 <= mapInfo.players);
+                      (switchFactionIdx + 1 <= maxSlots);
                     listBoxTeams[switchFactionIdx].setVisible
-                      (switchFactionIdx + 1 <= mapInfo.players);
+                      (switchFactionIdx + 1 <= maxSlots);
                     labelNetStatus[switchFactionIdx].setVisible
-                      (switchFactionIdx + 1 <= mapInfo.players);
+                      (switchFactionIdx + 1 <= maxSlots);
                   }
                 }
                 catch (const runtime_error & e)
@@ -4004,10 +4025,13 @@ namespace Glest
         SwitchSetupRequest **switchSetupRequests =
           serverInterface->getSwitchSetupRequests ();
 //!!!
+        int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
         switchSetupForSlots (switchSetupRequests, serverInterface, 0,
-                             mapInfo.players, false);
+                             maxSlots, false);
         switchSetupForSlots (switchSetupRequests, serverInterface,
-                             mapInfo.players, GameConstants::maxPlayers,
+                             maxSlots, GameConstants::maxPlayers,
                              true);
 
         if (SystemFlags::
@@ -4030,7 +4054,7 @@ namespace Glest
           (checkBoxEnableSwitchTeamMode.getValue ());
 
         int factionCount = 0;
-        for (int i = 0; i < mapInfo.players; ++i)
+        for (int i = 0; i < maxSlots; ++i)
         {
           if (hasNetworkGameSettings () == true)
           {
@@ -4324,13 +4348,13 @@ namespace Glest
               // close, nor did the slots become invisible when unchecking "Allow Observers"
               // I'm adding some lines
               // to this block to make sure that happens
-              listBoxControls[i].setSelectedItemIndex (ctClosed);
+             /*  listBoxControls[i].setSelectedItemIndex (ctClosed);
               labelPlayers[i].setVisible (false);
               labelPlayerNames[i].setVisible (false);
               listBoxControls[i].setVisible (false);
               listBoxFactions[i].setVisible (false);
               listBoxTeams[i].setVisible (false);
-              labelNetStatus[i].setVisible (false);
+              labelNetStatus[i].setVisible (false); */
               listBoxControls[i].setEditable (false);
               listBoxControls[i].setEnabled (false);
 
@@ -4347,10 +4371,13 @@ namespace Glest
                                     || slot->isConnected () == false)))
               {
                 listBoxControls[i].setEnabled (true);
-                listBoxControls[i].setEditable (i < mapInfo.players);
+                // listBoxControls[i].setEditable (i < mapInfo.players);
+                listBoxControls[i].setEditable (true);
 
                 if (i >= mapInfo.players && checkBoxAllowObservers.getValue () == 1)
                 {
+                  labelPlayers[i].setEditable (true);
+                  labelPlayerNames[i].setEditable (true);
                   listBoxControls[i].setSelectedItemIndex (ctNetwork);
                   listBoxFactions[i].setSelectedItem (GameConstants::OBSERVER_SLOTNAME);
                   listBoxFactions[i].setEditable (false);
@@ -4432,7 +4459,11 @@ namespace Glest
               && hasOneNetworkSlotOpen == false)
           {
             bool anyoneConnected = false;
-            for (int i = 0; i < mapInfo.players; ++i)
+
+            int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+            for (int i = 0; i < maxSlots; ++i)
             {
               MutexSafeWrapper
                 safeMutex ((publishToMasterserverThread !=
@@ -4451,7 +4482,7 @@ namespace Glest
               }
             }
 
-            for (int i = 0; i < mapInfo.players; ++i)
+            for (int i = 0; i < maxSlots; ++i)
             {
               if (anyoneConnected == false
                   && listBoxControls[i].getSelectedItemIndex () != ctNetwork)
@@ -4885,7 +4916,10 @@ namespace Glest
                                   (__FILE__).c_str (), __FUNCTION__,
                                   __LINE__);
 
-      for (int i = 0; i < mapInfo.players; ++i)
+      int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+      for (int i = 0; i < maxSlots; ++i)
       {
         if (listBoxControls[i].getSelectedItemIndex () != ctClosed)
         {
@@ -5677,6 +5711,9 @@ namespace Glest
           static_cast < ControlType >
           (listBoxControls[i].getSelectedItemIndex ());
 
+        int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
         if (forceCloseUnusedSlots == true
             && (ct == ctNetworkUnassigned || ct == ctNetwork))
         {
@@ -5693,8 +5730,7 @@ namespace Glest
             }
           }
         }
-
-        else if (ct == ctNetworkUnassigned && i < mapInfo.players)
+        else if (ct == ctNetworkUnassigned && i < maxSlots)
         {
           listBoxControls[i].setSelectedItemIndex (ctNetwork);
           ct = ctNetwork;
@@ -6118,7 +6154,10 @@ namespace Glest
         time_t clientConnectedTime = 0;
         bool masterserver_admin_found = false;
 
-        for (int i = 0; i < mapInfo.players; ++i)
+        int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+        for (int i = 0; i < maxSlots; ++i)
         {
 
 #ifdef DEBUG
@@ -6182,7 +6221,11 @@ namespace Glest
         }
         if (masterserver_admin_found == false)
         {
-          for (int i = mapInfo.players; i < GameConstants::maxPlayers; ++i)
+
+          int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+          for (int i = maxSlots; i < GameConstants::maxPlayers; ++i)
           {
             ServerInterface *serverInterface =
               NetworkManager::getInstance ().getServerInterface ();
@@ -6748,7 +6791,10 @@ namespace Glest
 
       try
       {
-        for (int i = 0; i < mapInfo.players; ++i)
+        int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+        for (int i = 0; i < maxSlots; ++i)
         {
           ControlType ct =
             static_cast < ControlType >
@@ -6888,7 +6934,10 @@ namespace Glest
       {
         bool humanPlayer = false;
 
-        for (int i = 0; i < mapInfo.players; ++i)
+        int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+        for (int i = 0; i < maxSlots; ++i)
         {
           if (listBoxControls[i].getSelectedItemIndex () == ctHuman)
           {
@@ -6901,7 +6950,7 @@ namespace Glest
           if (this->headlessServerMode == false)
           {
             bool foundNewSlotForHuman = false;
-            for (int i = 0; i < mapInfo.players; ++i)
+            for (int i = 0; i < maxSlots; ++i)
             {
               if (listBoxControls[i].getSelectedItemIndex () == ctClosed)
               {
@@ -6913,7 +6962,7 @@ namespace Glest
 
             if (foundNewSlotForHuman == false)
             {
-              for (int i = 0; i < mapInfo.players; ++i)
+              for (int i = 0; i < maxSlots; ++i)
               {
                 if (listBoxControls[i].getSelectedItemIndex () ==
                     ctClosed
@@ -6948,7 +6997,7 @@ namespace Glest
           }
         }
 
-        for (int i = mapInfo.players; i < GameConstants::maxPlayers; ++i)
+        for (int i = maxSlots; i < GameConstants::maxPlayers; ++i)
         {
           if (listBoxControls[i].getSelectedItemIndex () != ctNetwork &&
               listBoxControls[i].getSelectedItemIndex () !=
@@ -7083,10 +7132,13 @@ namespace Glest
           slot = serverInterface->getSlot (i, true);
           if (slot != NULL)
           {
+            int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
             if ((listBoxControls[i].getSelectedItemIndex () != ctNetwork)
                 || (listBoxControls[i].getSelectedItemIndex () ==
                     ctNetwork && slot->isConnected () == false
-                    && i >= mapInfo.players))
+                    && i >= maxSlots))
             {
               if (slot->getCanAcceptConnections () == true)
               {
@@ -7620,7 +7672,10 @@ namespace Glest
 // Loop twice to set the human slot or else it closes network slots in some cases
           for (int humanIndex = 0; humanIndex < 2; ++humanIndex)
           {
-            for (int i = 0; i < mapInfo.players; ++i)
+            int maxSlots = checkBoxAllowObservers.getValue () == 0 ?
+                                        mapInfo.players : GameConstants::maxPlayers;
+
+            for (int i = 0; i < maxSlots; ++i)
             {
               listBoxRMultiplier[i].setSelectedItem (floatToStr
                                                      (scenarioInfo.

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -5677,9 +5677,6 @@ namespace Glest
           static_cast < ControlType >
           (listBoxControls[i].getSelectedItemIndex ());
 
-        int maxSlots;
-        maxSlots = checkBoxAllowObservers.getValue () ? GameConstants::maxPlayers : mapInfo.players;
-
         if (forceCloseUnusedSlots == true
             && (ct == ctNetworkUnassigned || ct == ctNetwork))
         {
@@ -5699,9 +5696,6 @@ namespace Glest
 
         else if (ct == ctNetworkUnassigned && i < mapInfo.players)
         {
-          SystemFlags::OutputDebug (SystemFlags::debugSystem,
-                                          "maxSlots = %d\n",
-                                          maxSlots);
           listBoxControls[i].setSelectedItemIndex (ctNetwork);
           ct = ctNetwork;
         }
@@ -6855,15 +6849,6 @@ namespace Glest
               listBoxFactions[i].setVisible (true);
               listBoxTeams[i].setVisible (true);
               labelNetStatus[i].setVisible (true);
-
-              if (i > mapInfo->players)
-              {
-                // listBoxControls[i].setSelectedItemIndex (ctNetworkUnassigned);
-
-                // listBoxTeams[i].setSelectedItem (intToStr
-                                             //(GameConstants::maxPlayers +
-                                              //fpt_Observer));
-              }
             }
           }
 

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -876,17 +876,6 @@ namespace Glest
 
           if (openNetworkSlots == true)
           {
-
-            // Only enable all slots if AllowedObservers == 1
-            //
-            // This has no apparent effect. I think a combination of things
-            // must be set
-            //
-            /* int maxSlots;
-
-            maxSlots = checkBoxAllowObservers.getValue () ? GameConstants::maxPlayers : mapInfo.players;
-
-            for (int i = 1; i < maxSlots; ++i) */
             for (int i = 1; i < mapInfo.players; ++i)
             {
               listBoxControls[i].setSelectedItemIndex (ctNetwork);
@@ -4331,7 +4320,17 @@ namespace Glest
           for (int i = 0; i < GameConstants::maxPlayers; ++i)
           {
             if (i >= mapInfo.players && checkBoxAllowObservers.getValue () == 0)
-            {
+            { // After observer mode was added, slots >= mapInfo.players didn't
+              // close, nor did the slots become invisible when unchecking "Allow Observers"
+              // I'm adding some lines
+              // to this block to make sure that happens
+              listBoxControls[i].setSelectedItemIndex (ctClosed);
+              labelPlayers[i].setVisible (false);
+              labelPlayerNames[i].setVisible (false);
+              listBoxControls[i].setVisible (false);
+              listBoxFactions[i].setVisible (false);
+              listBoxTeams[i].setVisible (false);
+              labelNetStatus[i].setVisible (false);
               listBoxControls[i].setEditable (false);
               listBoxControls[i].setEnabled (false);
 
@@ -4347,27 +4346,23 @@ namespace Glest
                       ctNetwork && (slot == NULL
                                     || slot->isConnected () == false)))
               {
-                listBoxControls[i].setEditable (true);
                 listBoxControls[i].setEnabled (true);
+                listBoxControls[i].setEditable (i < mapInfo.players);
 
-                // This has no effect. I think because the slot is still "closed", not
-                // yet open to network players. I have to find out a better place for it
-                // -andy5995 2017-01-27
-
-/*                if (i >= mapInfo.players && checkBoxAllowObservers.getValue () == 1)
+                if (i >= mapInfo.players && checkBoxAllowObservers.getValue () == 1)
                 {
-                  gameSettings.setFactionTypeName (i, formatString (GameConstants::OBSERVER_SLOTNAME));
-
+                  listBoxControls[i].setSelectedItemIndex (ctNetwork);
+                  listBoxFactions[i].setSelectedItem (GameConstants::OBSERVER_SLOTNAME);
+                  listBoxFactions[i].setEditable (false);
                   listBoxTeams[i].setSelectedItem (intToStr (GameConstants::maxPlayers +
                                                   fpt_Observer));
-                } */
+                  listBoxTeams[i].setEditable (false);
+                }
               }
               else
               {
                 listBoxControls[i].setEditable (false);
                 listBoxControls[i].setEnabled (false);
-
-//printf("In [%s::%s] Line: %d i = %d mapInfo.players = %d\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,i,mapInfo.players);
               }
             }
             else
@@ -5702,8 +5697,6 @@ namespace Glest
           }
         }
 
-        // This has no apparent effect
-        // else if (ct == ctNetworkUnassigned && i < maxSlots)
         else if (ct == ctNetworkUnassigned && i < mapInfo.players)
         {
           SystemFlags::OutputDebug (SystemFlags::debugSystem,

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -418,7 +418,7 @@ namespace Glest
         checkBoxAllowObservers.registerGraphicComponent (containerName,
                                                          "checkBoxAllowObservers");
         checkBoxAllowObservers.init (xoffset + 325, aPos);
-        checkBoxAllowObservers.setValue (false);
+        checkBoxAllowObservers.setValue (checkBoxAllowObservers.getValue ());
 
         vector < string > rMultiplier;
         for (int i = 0; i < 45; ++i)
@@ -5687,14 +5687,17 @@ namespace Glest
           gameSettings->setFactionControl (slotIndex, ct);
           if (ct == ctHuman)
           {
-            if (SystemFlags::getSystemSettingType (SystemFlags::debugSystem).
-                enabled)
-              SystemFlags::OutputDebug (SystemFlags::debugSystem,
+
+// I'm putting this inside a ppd for now. I don't see it needs to be
+// built in unless DEBUG is defined during building -andy5995 2018-01-26
+#ifdef DEBUG
+   SystemFlags::OutputDebug (SystemFlags::debugSystem,
                                         "In [%s::%s Line: %d] i = %d, slotIndex = %d, getHumanPlayerName(i) [%s]\n",
                                         extractFileFromDirectoryPath
                                         (__FILE__).c_str (), __FUNCTION__,
                                         __LINE__, i, slotIndex,
                                         getHumanPlayerName (i).c_str ());
+#endif
 
             gameSettings->setThisFactionIndex (slotIndex);
             gameSettings->setNetworkPlayerName (slotIndex,
@@ -5722,24 +5725,22 @@ namespace Glest
                                                      ());
           }
 
-//if(slotIndex == 0) printf("slotIndex = %d, i = %d, multiplier = %d\n",slotIndex,i,listBoxRMultiplier[i].getSelectedItemIndex());
-
-//printf("Line: %d multiplier index: %d slotIndex: %d\n",__LINE__,listBoxRMultiplier[i].getSelectedItemIndex(),slotIndex);
           gameSettings->setResourceMultiplierIndex (slotIndex,
                                                     listBoxRMultiplier
                                                     [i].getSelectedItemIndex
                                                     ());
-//printf("Line: %d multiplier index: %d slotIndex: %d\n",__LINE__,gameSettings->getResourceMultiplierIndex(slotIndex),slotIndex);
 
-          if (SystemFlags::getSystemSettingType (SystemFlags::debugSystem).
-              enabled)
-            SystemFlags::OutputDebug (SystemFlags::debugSystem,
+// I'm putting this inside a ppd for now. I don't see it needs to be
+// built in unless DEBUG is defined during building -andy5995 2018-01-26
+#ifdef DEBUG
+   SystemFlags::OutputDebug (SystemFlags::debugSystem,
                                       "In [%s::%s Line: %d] i = %d, factionFiles[listBoxFactions[i].getSelectedItemIndex()] [%s]\n",
                                       extractFileFromDirectoryPath (__FILE__).
                                       c_str (), __FUNCTION__, __LINE__, i,
                                       factionFiles[listBoxFactions
                                                    [i].getSelectedItemIndex
                                                    ()].c_str ());
+#endif
 
           gameSettings->setFactionTypeName (slotIndex,
                                             factionFiles[listBoxFactions
@@ -5812,9 +5813,10 @@ namespace Glest
                                                        true)->getNetworkPlayerStatus
                                                       ());
 
-              if (SystemFlags::getSystemSettingType
-                  (SystemFlags::debugSystem).enabled)
-                SystemFlags::OutputDebug (SystemFlags::debugSystem,
+// I'm putting this inside a ppd for now. I don't see it needs to be
+// built in unless DEBUG is defined during building -andy5995 2018-01-26
+#ifdef DEBUG
+   SystemFlags::OutputDebug (SystemFlags::debugSystem,
                                           "In [%s::%s Line: %d] i = %d, connectionSlot->getName() [%s]\n",
                                           extractFileFromDirectoryPath
                                           (__FILE__).c_str (), __FUNCTION__,
@@ -5822,6 +5824,7 @@ namespace Glest
                                           serverInterface->getSlot (i,
                                                                     true)->getName
                                           ().c_str ());
+#endif
 
               gameSettings->setNetworkPlayerName (slotIndex,
                                                   serverInterface->getSlot (i,
@@ -5840,13 +5843,16 @@ namespace Glest
             }
             else
             {
-              if (SystemFlags::getSystemSettingType
-                  (SystemFlags::debugSystem).enabled)
-                SystemFlags::OutputDebug (SystemFlags::debugSystem,
+
+// I'm putting this inside a ppd for now. I don't see it needs to be
+// built in unless DEBUG is defined during building -andy5995 2018-01-26
+#ifdef DEBUG
+   SystemFlags::OutputDebug (SystemFlags::debugSystem,
                                           "In [%s::%s Line: %d] i = %d, playername unconnected\n",
                                           extractFileFromDirectoryPath
                                           (__FILE__).c_str (), __FUNCTION__,
                                           __LINE__, i);
+#endif
 
               gameSettings->setNetworkPlayerName (slotIndex,
                                                   GameConstants::NETWORK_SLOT_UNCONNECTED_SLOTNAME);
@@ -5856,13 +5862,14 @@ namespace Glest
           else if (listBoxControls[i].getSelectedItemIndex () != ctHuman)
           {
             AIPlayerCount++;
-            if (SystemFlags::getSystemSettingType (SystemFlags::debugSystem).
-                enabled)
-              SystemFlags::OutputDebug (SystemFlags::debugSystem,
+
+#ifdef DEBUG
+   SystemFlags::OutputDebug (SystemFlags::debugSystem,
                                         "In [%s::%s Line: %d] i = %d, playername is AI (blank)\n",
                                         extractFileFromDirectoryPath
                                         (__FILE__).c_str (), __FUNCTION__,
                                         __LINE__, i);
+#endif
 
             Lang & lang = Lang::getInstance ();
             gameSettings->setNetworkPlayerName (slotIndex,
@@ -6091,16 +6098,16 @@ namespace Glest
       {
         time_t clientConnectedTime = 0;
         bool masterserver_admin_found = false;
-//printf("mapInfo.players [%d]\n",mapInfo.players);
 
         for (int i = 0; i < mapInfo.players; ++i)
         {
-          if (SystemFlags::getSystemSettingType (SystemFlags::debugSystem).
-              enabled)
-            SystemFlags::OutputDebug (SystemFlags::debugSystem,
+
+#ifdef DEBUG
+   SystemFlags::OutputDebug (SystemFlags::debugSystem,
                                       "In [%s::%s Line %d]\n",
                                       extractFileFromDirectoryPath (__FILE__).
                                       c_str (), __FUNCTION__, __LINE__);
+#endif
 
           if (listBoxControls[i].getSelectedItemIndex () == ctNetwork
               || listBoxControls[i].getSelectedItemIndex () ==
@@ -6806,13 +6813,33 @@ namespace Glest
                 }
               }
             }
-            mapInfo->players = GameConstants::maxPlayers;
-            labelPlayers[i].setVisible (i + 1 <= mapInfo->players);
-            labelPlayerNames[i].setVisible (i + 1 <= mapInfo->players);
-            listBoxControls[i].setVisible (i + 1 <= mapInfo->players);
-            listBoxFactions[i].setVisible (i + 1 <= mapInfo->players);
-            listBoxTeams[i].setVisible (i + 1 <= mapInfo->players);
-            labelNetStatus[i].setVisible (i + 1 <= mapInfo->players);
+            if (checkBoxAllowObservers.getValue () != 1)
+            {
+              labelPlayers[i].setVisible (i + 1 <= mapInfo->players);
+              labelPlayerNames[i].setVisible (i + 1 <= mapInfo->players);
+              listBoxControls[i].setVisible (i + 1 <= mapInfo->players);
+              listBoxFactions[i].setVisible (i + 1 <= mapInfo->players);
+              listBoxTeams[i].setVisible (i + 1 <= mapInfo->players);
+              labelNetStatus[i].setVisible (i + 1 <= mapInfo->players );
+            }
+            else
+            {
+              labelPlayers[i].setVisible (true);
+              labelPlayerNames[i].setVisible (true);
+              listBoxControls[i].setVisible (true);
+              listBoxFactions[i].setVisible (true);
+              listBoxTeams[i].setVisible (true);
+              labelNetStatus[i].setVisible (true);
+
+              if (i > mapInfo->players)
+              {
+                // listBoxControls[i].setSelectedItemIndex (ctNetworkUnassigned);
+
+                // listBoxTeams[i].setSelectedItem (intToStr
+                                             //(GameConstants::maxPlayers +
+                                              //fpt_Observer));
+              }
+            }
           }
 
 // Not painting properly so this is on hold

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -876,6 +876,17 @@ namespace Glest
 
           if (openNetworkSlots == true)
           {
+
+            // Only enable all slots if AllowedObservers == 1
+            //
+            // This has no apparent effect. I think a combination of things
+            // must be set
+            //
+            /* int maxSlots;
+
+            maxSlots = checkBoxAllowObservers.getValue () ? GameConstants::maxPlayers : mapInfo.players;
+
+            for (int i = 1; i < maxSlots; ++i) */
             for (int i = 1; i < mapInfo.players; ++i)
             {
               listBoxControls[i].setSelectedItemIndex (ctNetwork);
@@ -5671,6 +5682,9 @@ namespace Glest
           static_cast < ControlType >
           (listBoxControls[i].getSelectedItemIndex ());
 
+        int maxSlots;
+        maxSlots = checkBoxAllowObservers.getValue () ? GameConstants::maxPlayers : mapInfo.players;
+
         if (forceCloseUnusedSlots == true
             && (ct == ctNetworkUnassigned || ct == ctNetwork))
         {
@@ -5687,8 +5701,14 @@ namespace Glest
             }
           }
         }
+
+        // This has no apparent effect
+        // else if (ct == ctNetworkUnassigned && i < maxSlots)
         else if (ct == ctNetworkUnassigned && i < mapInfo.players)
         {
+          SystemFlags::OutputDebug (SystemFlags::debugSystem,
+                                          "maxSlots = %d\n",
+                                          maxSlots);
           listBoxControls[i].setSelectedItemIndex (ctNetwork);
           ct = ctNetwork;
         }

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -4319,7 +4319,7 @@ namespace Glest
         {
           for (int i = 0; i < GameConstants::maxPlayers; ++i)
           {
-            if (i >= mapInfo.players)
+            if (i >= mapInfo.players && checkBoxAllowObservers.getValue () == 0)
             {
               listBoxControls[i].setEditable (false);
               listBoxControls[i].setEnabled (false);
@@ -4338,6 +4338,18 @@ namespace Glest
               {
                 listBoxControls[i].setEditable (true);
                 listBoxControls[i].setEnabled (true);
+
+                // This has no effect. I think because the slot is still "closed", not
+                // yet open to network players. I have to find out a better place for it
+                // -andy5995 2017-01-27
+
+/*                if (i >= mapInfo.players && checkBoxAllowObservers.getValue () == 1)
+                {
+                  gameSettings.setFactionTypeName (i, formatString (GameConstants::OBSERVER_SLOTNAME));
+
+                  listBoxTeams[i].setSelectedItem (intToStr (GameConstants::maxPlayers +
+                                                  fpt_Observer));
+                } */
               }
               else
               {


### PR DESCRIPTION
This is WIP

## Goals

* Extra slots should only appear if observer mode is allowed
* Extra slots should be open
* Extra slots should be set to "observer" and non-editable

At this point, clicking on custom game with "allowed Observers" checked,
10 slots show up, but all the extra ones are closed.

De-selecting the "allow observers" checkbox doesn't make the extra slots
invisible until the map is changed or the map filter buttons are used.