### PR TITLE
Unit produce/ upgrade progress is now reset when completed or cancell…

### DIFF
--- a/source/glest_game/type_instances/unit.cpp
+++ b/source/glest_game/type_instances/unit.cpp
@@ -1337,7 +1337,7 @@ void Unit::setCurrSkill(const SkillType *currSkill) {
 		*/
 		checkCustomizedUnitParticleListTriggers(currSkill->unitParticleSystemTypes,true);
 	}
-	progress2= 0;
+
 	if(this->currSkill != currSkill) {
 		this->lastModelIndexForCurrSkillType = -1;
 		this->animationRandomCycleCount = 0;
@@ -1953,6 +1953,8 @@ std::pair<CommandResult,string> Unit::giveCommand(Command *command, bool tryQueu
 CommandResult Unit::finishCommand() {
 	changedActiveCommand = false;
 	retryCurrCommandCount=0;
+	// Reset the progress when task completed.
+	resetProgress2();
 	this->setCurrentUnitTitle("");
 	//is empty?
 	if(commands.empty()) {
@@ -1990,6 +1992,8 @@ CommandResult Unit::finishCommand() {
 CommandResult Unit::cancelCommand() {
 	changedActiveCommand = false;
 	retryCurrCommandCount=0;
+	// Reset the progress if the command (possibly a task) is cancelled.
+	resetProgress2();
 	this->setCurrentUnitTitle("");
 
 	//is empty?

--- a/source/glest_game/type_instances/unit.h
+++ b/source/glest_game/type_instances/unit.h
@@ -625,7 +625,7 @@ public:
 
     inline void setLoadCount(int loadCount)					{this->loadCount= loadCount;}
     inline void setLoadType(const ResourceType *loadType)		{this->loadType= loadType;}
-    inline void setProgress2(int progress2)					{this->progress2= progress2;}
+    inline void resetProgress2()					{this->progress2 = 0;}
 	void setPos(const Vec2i &pos,bool clearPathFinder=false, bool threaded=false);
 	void refreshPos(bool forceRefresh=false);
 	void setTargetPos(const Vec2i &targetPos, bool threaded=false);

--- a/source/glest_game/world/unit_updater.cpp
+++ b/source/glest_game/world/unit_updater.cpp
@@ -264,7 +264,7 @@ bool UnitUpdater::updateUnit(Unit *unit) {
 			unit->cancelCommand();
 
 			if(reQueueHoldPosition == true) {
-				//Search for a command that can produceproduce the unit
+				//Search for a command that can produce the unit
 				const UnitType *ut = unit->getType();
 				for(int i= 0; i < ut->getCommandTypeCount(); ++i) {
 					const CommandType* ct= ut->getCommandType(i);

--- a/source/glest_game/world/unit_updater.cpp
+++ b/source/glest_game/world/unit_updater.cpp
@@ -264,7 +264,7 @@ bool UnitUpdater::updateUnit(Unit *unit) {
 			unit->cancelCommand();
 
 			if(reQueueHoldPosition == true) {
-				//Search for a command that can produce the unit
+				//Search for a command that can produceproduce the unit
 				const UnitType *ut = unit->getType();
 				for(int i= 0; i < ut->getCommandTypeCount(); ++i) {
 					const CommandType* ct= ut->getCommandType(i);
@@ -305,7 +305,7 @@ bool UnitUpdater::updateUnit(Unit *unit) {
 				}
 			}
 		}
-		
+
 		//move unit in cells
 		if(unit->getCurrSkill()->getClass() == scMove) {
 			world->moveUnitCells(unit, true);
@@ -1823,7 +1823,7 @@ void UnitUpdater::updateHarvest(Unit *unit, int frameIndex) {
 
 					if (unit->getProgress2() >= hct->getHitsPerUnit()) {
 						if (unit->getLoadCount() < hct->getMaxLoad()) {
-							unit->setProgress2(0);
+							unit->resetProgress2();
 							unit->setLoadCount(unit->getLoadCount() + 1);
 
 							//if resource exausted, then delete it and stop
@@ -2359,7 +2359,9 @@ void UnitUpdater::updateProduce(Unit *unit, int frameIndex) {
 		if(SystemFlags::getSystemSettingType(SystemFlags::debugPerformance).enabled && chrono.getMillis() > 0) SystemFlags::OutputDebug(SystemFlags::debugPerformance,"In [%s::%s] Line: %d took msecs: %lld\n",__FILE__,__FUNCTION__,__LINE__,chrono.getMillis());
 
         if(unit->getProgress2() > pct->getProduced()->getProductionTime()){
+            // finish producing or upgrading if complete.
             unit->finishCommand();
+            // Stop the unit that finished upgrading.
             unit->setCurrSkill(scStop);
 
 			UnitPathInterface *newpath = NULL;
@@ -2682,7 +2684,7 @@ void UnitUpdater::damage(Unit *attacker, const AttackSkillType* ast, Unit *attac
 			int lootableResourceCount = attacked->getType()->getLootableResourceCount();
 			for(int i = 0; i < lootableResourceCount; i++) {
 				LootableResource resource = attacked->getType()->getLootableResource(i);
-			
+
 				// Figure out how much of the resource in question that the attacked unit's faction has
 				int factionTotalResource = 0;
 				for(int j = 0; j < attacked->getFaction()->getTechTree()->getResourceTypeCount(); j++) {
@@ -2691,7 +2693,7 @@ void UnitUpdater::damage(Unit *attacker, const AttackSkillType* ast, Unit *attac
 						break;
 					}
 				}
-			
+
 				if(resource.isNegativeAllowed()) {
 					attacked->getFaction()->incResourceAmount(resource.getResourceType(), -(factionTotalResource * resource.getLossFactionPercent() / 100));
 					attacked->getFaction()->incResourceAmount(resource.getResourceType(), -resource.getLossValue());


### PR DESCRIPTION
…ed instead of when it starts (which fixes issue #30).

Issue #30 was caused because of the following algorithm (and it did not only affect upgrades, but any production):
1. Update progress is loaded from save (the variable in question is called progress2).
2. Incomplete upgrade/ produce command is loaded as not completed.
3. Incomplete upgrades are restarted, which triggers update progress to reset.

This fix: Reset the update progress after the the produce command has finished, or if cancelled, instead of when it's started.

Problem with the fix: There will be a performance hit, because the the progress is unnecessarily reset if e.g. a walking command finishes or is cancelled (hopefully it's a small hit).

Another change I made is I changed the setter of the variable progress2 from "setProgress()" to "resetProgress()". The function "setProgress" was only used to set the progress to 0, so I replaced the function with "resetProgress()" which can only set progress to 0.