### PR TITLE
glestkeys.ini:change some keys

### DIFF
--- a/mk/shared/glestkeys.ini
+++ b/mk/shared/glestkeys.ini
@@ -2,7 +2,10 @@
 
 RenderInGamePerformance=`
 RenderNetworkStatus=N
+
+; Used for Chat History
 ShowFullConsole=H
+
 Screenshot=E
 FreeCameraMode=F
 ResetCameraMode=space

--- a/mk/shared/glestkeys.ini
+++ b/mk/shared/glestkeys.ini
@@ -2,7 +2,7 @@
 
 RenderInGamePerformance=`
 RenderNetworkStatus=N
-ShowFullConsole=Z
+ShowFullConsole=H
 Screenshot=E
 FreeCameraMode=F
 ResetCameraMode=space
@@ -37,12 +37,12 @@ HotKeyShowDebug=?
 HotKeyDumpWorldToLog=\
 HotKeyRotateUnitDuringPlacement=R
 HotKeySelectDamagedUnit=D
-HotKeySelectStoreUnit=T
+HotKeySelectStoreUnit=Z
 HotKeySelectedUnitsAttack=A
 HotKeySelectedUnitsMove=M
 HotKeySelectedUnitsStop=S
 HotKeyToggleOSMouseEnabled=/
-ChatTeamMode=H
+ChatTeamMode=T
 ToggleHealthbars=#
 ToggleMusic=K
 SaveGUILayout=f10


### PR DESCRIPTION
This corrects an error I made in
bf5a04be18f2b16b8a565acff4baabc5fbfed293

And T is now for team chat
H is for chat history (instead of "M")
Z is for HotKeySelectStoreUnit