### PR TITLE
when scenario xml file not present, don't err

### DIFF
--- a/source/glest_game/menu/menu_state_scenario.cpp
+++ b/source/glest_game/menu/menu_state_scenario.cpp
@@ -598,15 +598,12 @@ namespace Glest
       bool isTutorial = Scenario::isGameTutorial (file);
 
       cleanupPreviewTexture ();
+      needToLoadTextures = false;
 
       if (Scenario::loadScenarioInfo (file, scenarioInfo, isTutorial) == true)
       {
         previewLoadDelayTimer = time (NULL);
         needToLoadTextures = true;
-      }
-      else
-      {
-        needToLoadTextures = false;
       }
     }
 

--- a/source/glest_game/menu/menu_state_scenario.cpp
+++ b/source/glest_game/menu/menu_state_scenario.cpp
@@ -597,13 +597,17 @@ namespace Glest
     {
       bool isTutorial = Scenario::isGameTutorial (file);
 
-      //printf("[%s:%s] Line: %d file [%s]\n",extractFileFromDirectoryPath(__FILE__).c_str(),__FUNCTION__,__LINE__,file.c_str());
-
-      Scenario::loadScenarioInfo (file, scenarioInfo, isTutorial);
-
       cleanupPreviewTexture ();
-      previewLoadDelayTimer = time (NULL);
-      needToLoadTextures = true;
+
+      if (Scenario::loadScenarioInfo (file, scenarioInfo, isTutorial) == true)
+      {
+        previewLoadDelayTimer = time (NULL);
+        needToLoadTextures = true;
+      }
+      else
+      {
+        needToLoadTextures = false;
+      }
     }
 
     void MenuStateScenario::loadScenarioPreviewTexture ()

--- a/source/glest_game/world/scenario.cpp
+++ b/source/glest_game/world/scenario.cpp
@@ -237,9 +237,25 @@ namespace Glest {
       return isTutorial;
     }
 
-    void Scenario::loadScenarioInfo(string file,
+    bool Scenario::loadScenarioInfo(string file,
                                     ScenarioInfo * scenarioInfo,
                                     bool isTutorial) {
+      if (fileExists (file) == false)
+      {
+        // FIXME: A new string will need a new translation; we haven't
+        // discussed how we'll deal with translations yet.
+        //
+        // this particular string is just a placeholder, and will hopefully
+        // get changed soon, when we can point a user to complete documentation
+        // on how to obtain a scenario
+        // -andy5995 2018-02-01
+        scenarioInfo->desc = "This scenario will be available soon.\n\n\
+Please contact the ZetaGlest team for more info.";
+
+        scenarioInfo->name = file;
+        return false;
+      }
+
       //printf("[%s:%s] Line: %d file [%s]\n",__FILE__,__FUNCTION__,__LINE__,file.c_str());
       if (SystemFlags::VERBOSE_MODE_ENABLED)
         printf("In [%s::%s Line: %d] file [%s]\n",
@@ -514,6 +530,8 @@ namespace Glest {
       scenarioInfo->file = file;
       scenarioInfo->name = extractFileFromDirectoryPath(file);
       scenarioInfo->name = cutLastExt(scenarioInfo->name);
+
+      return true;
 
       //scenarioLogoTexture = NULL;
       //cleanupPreviewTexture();

--- a/source/glest_game/world/scenario.h
+++ b/source/glest_game/world/scenario.h
@@ -172,7 +172,7 @@ namespace Glest {
       static string getScenarioDir(const vector < string > dir,
                                    const string & scenarioName);
 
-      static void loadScenarioInfo(string file,
+      static bool loadScenarioInfo(string file,
                                    ScenarioInfo * scenarioInfo,
                                    bool isTutorial);
       static ControlType strToControllerType(const string & str);


### PR DESCRIPTION
For ZetaGlest/zetaglest-data#30

To add mods as submodules, the directory must exist. But until the scenario is pulled by a user, there is no xml file inside the dir.

This patch prevents the error on the screen and in the console.

This is how it looks now with my patch if an xml file is not present:

![screen29](https://user-images.githubusercontent.com/16764864/35666898-62e31982-06f1-11e8-987e-66f12ad093e8.jpg)

I tested it, it works, but my code can be reviewed. Can it be made cleaner?

One problem is that the play now button is still clickable. That can be done in a separate ticket. This at least means a user won't get an error just scrolling through the scenario list. (They will if they hit the "play now" button)