### PR TITLE
menu_state_connected_game:disable slots > max map players

### DIFF
--- a/source/glest_game/menu/menu_state_connected_game.cpp
+++ b/source/glest_game/menu/menu_state_connected_game.cpp
@@ -4555,17 +4555,37 @@ namespace Glest
                 hasOtherPlayer = true;
               }
             }
-            else if (clientInterface->getPlayerIndex () == (int) i)
+            else if (clientInterface->getPlayerIndex () == (int) i ||
+                      i >= mapInfo.hardMaxPlayers)
             {
+              // Most of the code that handles how to show the set up
+              // when observers are allowed is in the update() function
+              // in menu_state_custom_game.cpp. Explicitly stating to change
+              // players to observers, changing teams to the special "observer"
+              // team is done in that function. So basically, the update() function
+              // in this file receives the info from update() in
+              // menu_state_custom_game.cpp
+              //
+              // Mostly what needs to be done here is disable observer slots
+              // so the info can't be changed by the headless admin. We don't want
+              // him or her to accidently enable a non-observer into an observer slot
+              // that's > mapInfo.hardMaxPlayers, or to change the team.
+              //
               listBoxControls[i].setEditable (false);
             }
             else
             {
-              listBoxControls[i].setEditable (true);
+              if (i < mapInfo.hardMaxPlayers)
+              {
+                listBoxControls[i].setEditable (true);
+              }
             }
-            listBoxRMultiplier[i].setEditable (isHeadlessAdmin ());
-            listBoxFactions[i].setEditable (isHeadlessAdmin ());
-            listBoxTeams[i].setEditable (isHeadlessAdmin ());
+            if (i < mapInfo.hardMaxPlayers)
+            {
+              listBoxRMultiplier[i].setEditable (isHeadlessAdmin ());
+              listBoxFactions[i].setEditable (isHeadlessAdmin ());
+              listBoxTeams[i].setEditable (isHeadlessAdmin ());
+            }
           }
           if (hasOtherPlayer)
           {

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -4369,26 +4369,29 @@ namespace Glest
 
           for (int i = 0; i < GameConstants::maxPlayers; ++i)
           {
-            if (i >= mapInfo.hardMaxPlayers && checkBoxAllowObservers.getValue() == false)
+            if (i >= mapInfo.hardMaxPlayers)
             {
-              listBoxControls[i].setSelectedItemIndex (ctClosed);
-              listBoxControls[i].setEditable (false);
-              listBoxControls[i].setEnabled (false);
-              listBoxRMultiplier[i].setEditable (false);
-              listBoxRMultiplier[i].setEnabled (false);
-            }
-            else if (i >= mapInfo.hardMaxPlayers && checkBoxAllowObservers.getValue() == true)
-            {
-              listBoxControls[i].setSelectedItemIndex (ctNetwork);
-              listBoxControls[i].setEditable (false);
-              listBoxFactions[i].setSelectedItem (GameConstants::OBSERVER_SLOTNAME);
-              listBoxFactions[i].setEditable (false);
-              listBoxTeams[i].setSelectedItem (intToStr (GameConstants::maxPlayers +
-                                              fpt_Observer));
-              listBoxTeams[i].setEditable (false);
-              listBoxRMultiplier[i].setEditable (false);
-              listBoxRMultiplier[i].setEnabled (false);
-              listBoxRMultiplier[i].setVisible (false);
+              if (checkBoxAllowObservers.getValue() == false)
+              {
+                listBoxControls[i].setSelectedItemIndex (ctClosed);
+                listBoxControls[i].setEditable (false);
+                listBoxControls[i].setEnabled (false);
+                listBoxRMultiplier[i].setEditable (false);
+                listBoxRMultiplier[i].setEnabled (false);
+              }
+              else
+              {
+                listBoxControls[i].setSelectedItemIndex (ctNetwork);
+                listBoxControls[i].setEditable (false);
+                listBoxFactions[i].setSelectedItem (GameConstants::OBSERVER_SLOTNAME);
+                listBoxFactions[i].setEditable (false);
+                listBoxTeams[i].setSelectedItem (intToStr (GameConstants::maxPlayers +
+                                                fpt_Observer));
+                listBoxTeams[i].setEditable (false);
+                listBoxRMultiplier[i].setEditable (false);
+                listBoxRMultiplier[i].setEnabled (false);
+                listBoxRMultiplier[i].setVisible (false);
+              }
             }
             else if (listBoxControls[i].getSelectedItemIndex () !=
                      ctNetworkUnassigned)


### PR DESCRIPTION
This disables slots >= mapInfo.hardMaxPlayers from headless admin
control.

I forgot to check how the menu looked when connecting to a headless
server when I "completed" #13.