### PR TITLE
add new function for playing sfx

### DIFF
--- a/mk/linux/glest.ini
+++ b/mk/linux/glest.ini
@@ -96,6 +96,18 @@ VersionURL=http://zetaglest.dreamhosters.com/files/versions/
 Windowed=false
 
 ; sfx
+; These can be over-ridden by adding the variables to your glestuser.ini
+; file.
+;
+; FIXME: There should be a way to use the "DataPath" variable
+; here (defined above)
 PlaySoundAttention=../../../zetaglest-data/data/core/menu/sound/attention.wav
 PlaySoundHighlight=../../../zetaglest-data/data/core/menu/sound/highlight.wav
 PlaySoundNewServer=../../../zetaglest-data/data/core/menu/sound/attention.wav
+PlaySoundMarker=../../../zetaglest-data/data/core/menu/sound/sonar.wav
+
+; it's recommended that users not over-ride these. The sounds are just for
+; menu clicks and should remain very short in duration.
+PlaySoundMenuClickA=../../../zetaglest-data/data/core/menu/sound/click_a.wav
+PlaySoundMenuClickB=../../../zetaglest-data/data/core/menu/sound/click_b.wav
+PlaySoundMenuClickC=../../../zetaglest-data/data/core/menu/sound/click_c.wav

--- a/mk/macos/glest.ini
+++ b/mk/macos/glest.ini
@@ -94,6 +94,20 @@ VersionURL=http://zetaglest.dreamhosters.com/files/versions/
 Windowed=true
 
 ; sfx
+; These can be over-ridden by adding the variables to your glestuser.ini
+; file.
+;
+; FIXME: There should be a way to use the "DataPath" variable
+; here (defined above)
 PlaySoundAttention=../../../zetaglest-data/data/core/menu/sound/attention.wav
 PlaySoundHighlight=../../../zetaglest-data/data/core/menu/sound/highlight.wav
 PlaySoundNewServer=../../../zetaglest-data/data/core/menu/sound/attention.wav
+PlaySoundMarker=../../../zetaglest-data/data/core/menu/sound/sonar.wav
+
+; it's recommended that users not over-ride these. The sounds are just for
+; menu clicks and should remain very short in duration.
+; it's recommended that users not over-ride these. The sounds are just for
+; menu clicks and should remain very short in duration.
+PlaySoundMenuClickA=../../../zetaglest-data/data/core/menu/sound/click_a.wav
+PlaySoundMenuClickB=../../../zetaglest-data/data/core/menu/sound/click_b.wav
+PlaySoundMenuClickC=../../../zetaglest-data/data/core/menu/sound/click_c.wav

--- a/mk/windows/glest.ini
+++ b/mk/windows/glest.ini
@@ -96,6 +96,18 @@ VersionURL=http://zetaglest.dreamhosters.com/files/versions/
 Windowed=false
 
 ; sfx
+; These can be over-ridden by adding the variables to your glestuser.ini
+; file.
+;
+; FIXME: There should be a way to use the "DataPath" variable
+; here (defined above)
 PlaySoundAttention=..\..\..\zetaglest-data\data\core\menu\sound\attention.wav
 PlaySoundHighlight=..\..\..\zetaglest-data\data\core\menu\sound\highlight.wav
 PlaySoundNewServer=..\..\..\zetaglest-data\data\core\menu\sound\attention.wav
+PlaySoundMarker=..\..\..\zetaglest-data\data\core\menu\sound\sonar.wav
+
+; it's recommended that users not over-ride these. The sounds are just for
+; menu clicks and should remain very short in duration.
+PlaySoundMenuClickA=..\..\..\zetaglest-data\data\core\menu\sound\click_a.wav
+PlaySoundMenuClickB=..\..\..\zetaglest-data\data\core\menu\sound\click_b.wav
+PlaySoundMenuClickC=..\..\..\zetaglest-data\data\core\menu\sound\click_c.wav

--- a/source/glest_game/CMakeLists.txt
+++ b/source/glest_game/CMakeLists.txt
@@ -178,10 +178,10 @@ IF(BUILD_MEGAGLEST)
 	# megaglest game
 
 	SET(DIRS_WITH_SRC
-	   	ai
+		global
+		ai
 		facilities
 		game
-		global
 		graphics
 		gui
 		main

--- a/source/glest_game/CMakeLists.txt
+++ b/source/glest_game/CMakeLists.txt
@@ -178,10 +178,10 @@ IF(BUILD_MEGAGLEST)
 	# megaglest game
 
 	SET(DIRS_WITH_SRC
-		global
-		ai
+	   	ai
 		facilities
 		game
+		global
 		graphics
 		gui
 		main

--- a/source/glest_game/game/chat_manager.cpp
+++ b/source/glest_game/game/chat_manager.cpp
@@ -790,12 +790,10 @@ namespace
                             if (msg.chatText.find (playerName) !=
                                 string::npos)
                               {
-                                CoreData & coreData =
-                                  CoreData::getInstance ();
-                                PlaySoundClip play;
+                                 static PlaySoundClip snd;
                                 SoundRenderer & soundRenderer =
                                   SoundRenderer::getInstance ();
-                                soundRenderer.playFx (play.getSound (play.sfxHighlight),
+                                soundRenderer.playFx (snd.getSound (snd.sfxHighlight),
                                                       true);
                               }
                             console->addLine (msg.chatText.

--- a/source/glest_game/game/chat_manager.cpp
+++ b/source/glest_game/game/chat_manager.cpp
@@ -1,13 +1,25 @@
-// ==============================================================
-//      This file is part of Glest (www.glest.org)
 //
-//      Copyright (C) 2001-2008 Martiño Figueroa
+//      chat_manager.cpp: game setup menu as it appears to
+//      to the host
 //
-//      You can redistribute this code and/or modify it under
-//      the terms of the GNU General Public License as published
-//      by the Free Software Foundation; either version 2 of the
-//      License, or (at your option) any later version
-// ==============================================================
+//      This file is part of ZetaGlest <https://github.com/ZetaGlest>
+//
+//      Copyright (C) 2018  The ZetaGlest team
+//
+//      ZetaGlest is a fork of MegaGlest <https://megaglest.org>
+//
+//      This program is free software: you can redistribute it and/or modify
+//      it under the terms of the GNU General Public License as published by
+//      the Free Software Foundation, either version 3 of the License, or
+//      (at your option) any later version.
+//
+//      This program is distributed in the hope that it will be useful,
+//      but WITHOUT ANY WARRANTY; without even the implied warranty of
+//      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//      GNU General Public License for more details.
+//
+//      You should have received a copy of the GNU General Public License
+//      along with this program.  If not, see <https://www.gnu.org/licenses/>
 
 #include "chat_manager.h"
 
@@ -783,7 +795,7 @@ namespace
                                 SoundRenderer & soundRenderer =
                                   SoundRenderer::getInstance ();
                                 soundRenderer.playFx (coreData.
-                                                      getHighlightSound (),
+                                                      getSound (CoreData::sfxHighlight),
                                                       true);
                               }
                             console->addLine (msg.chatText.

--- a/source/glest_game/game/chat_manager.cpp
+++ b/source/glest_game/game/chat_manager.cpp
@@ -792,10 +792,10 @@ namespace
                               {
                                 CoreData & coreData =
                                   CoreData::getInstance ();
+                                PlaySoundClip play;
                                 SoundRenderer & soundRenderer =
                                   SoundRenderer::getInstance ();
-                                soundRenderer.playFx (coreData.
-                                                      getSound (CoreData::sfxHighlight),
+                                soundRenderer.playFx (play.getSound (play.sfxHighlight),
                                                       true);
                               }
                             console->addLine (msg.chatText.

--- a/source/glest_game/game/chat_manager.h
+++ b/source/glest_game/game/chat_manager.h
@@ -1,13 +1,25 @@
-// ==============================================================
-//      This file is part of Glest (www.glest.org)
 //
-//      Copyright (C) 2001-2008 Martiño Figueroa
+//      chat_manager.h: game setup menu as it appears to
+//      to the host
 //
-//      You can redistribute this code and/or modify it under
-//      the terms of the GNU General Public License as published
-//      by the Free Software Foundation; either version 2 of the
-//      License, or (at your option) any later version
-// ==============================================================
+//      This file is part of ZetaGlest <https://github.com/ZetaGlest>
+//
+//      Copyright (C) 2018  The ZetaGlest team
+//
+//      ZetaGlest is a fork of MegaGlest <https://megaglest.org>
+//
+//      This program is free software: you can redistribute it and/or modify
+//      it under the terms of the GNU General Public License as published by
+//      the Free Software Foundation, either version 3 of the License, or
+//      (at your option) any later version.
+//
+//      This program is distributed in the hope that it will be useful,
+//      but WITHOUT ANY WARRANTY; without even the implied warranty of
+//      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//      GNU General Public License for more details.
+//
+//      You should have received a copy of the GNU General Public License
+//      along with this program.  If not, see <https://www.gnu.org/licenses/>
 
 #ifndef _GLEST_GAME_CHATMANAGER_H_
 #   define _GLEST_GAME_CHATMANAGER_H_

--- a/source/glest_game/game/game.cpp
+++ b/source/glest_game/game/game.cpp
@@ -4820,7 +4820,8 @@ namespace Glest
             (faction->getTeam () ==
              getWorld ()->getThisFaction ()->getTeam ()))
         {
-          soundRenderer.playFx (coreData.getMarkerSound (), true);
+          static PlaySoundClip snd;
+          soundRenderer.playFx (snd.getSound (snd.sfxMarker), true);
         }
       }
     }

--- a/source/glest_game/game/game_constants.h
+++ b/source/glest_game/game/game_constants.h
@@ -1,13 +1,25 @@
-// ==============================================================
-//      This file is part of Glest (www.glest.org)
 //
-//      Copyright (C) 2001-2008 Martiño Figueroa
+//      game_constants.h: game setup menu as it appears to
+//      to the host
 //
-//      You can redistribute this code and/or modify it under
-//      the terms of the GNU General Public License as published
-//      by the Free Software Foundation; either version 2 of the
-//      License, or (at your option) any later version
-// ==============================================================
+//      This file is part of ZetaGlest <https://github.com/ZetaGlest>
+//
+//      Copyright (C) 2018  The ZetaGlest team
+//
+//      ZetaGlest is a fork of MegaGlest <https://megaglest.org>
+//
+//      This program is free software: you can redistribute it and/or modify
+//      it under the terms of the GNU General Public License as published by
+//      the Free Software Foundation, either version 3 of the License, or
+//      (at your option) any later version.
+//
+//      This program is distributed in the hope that it will be useful,
+//      but WITHOUT ANY WARRANTY; without even the implied warranty of
+//      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//      GNU General Public License for more details.
+//
+//      You should have received a copy of the GNU General Public License
+//      along with this program.  If not, see <https://www.gnu.org/licenses/>
 
 #ifndef _GLEST_GAME_GAMECONSTANTS_H_
 #   define _GLEST_GAME_GAMECONSTANTS_H_
@@ -298,7 +310,6 @@ namespace
         HUD_SCREEN_FILE;
       static const char *
         HUD_SCREEN_FILE_FILTER;
-
     };
 
     enum PathType

--- a/source/glest_game/global/core_data.cpp
+++ b/source/glest_game/global/core_data.cpp
@@ -63,6 +63,12 @@ namespace Glest
 
     static const string CORE_WATER_SOUNDS_PATH = CORE_PATH + "/water_sounds/";
 
+    // Sound effects
+    // These variables are specified in the ini file
+    static const std::string sfxAttention = "PlaySoundAttention";
+    static const std::string sfxHighlight = "PlaySoundHighlight";
+    static const std::string sfxNewServer = "PlaySoundNewServer";
+
     CoreData & CoreData::getInstance ()
     {
       static CoreData coreData;
@@ -748,80 +754,6 @@ namespace Glest
       return &iniPlaySound;
     }
 
-    StaticSound *CoreData::getAttentionSound ()
-    {
-      int loadAttemptLookupKey = tsyst_COUNT + 6;
-      if (itemLoadAttempted.find (loadAttemptLookupKey) ==
-          itemLoadAttempted.end ())
-      {
-
-        itemLoadAttempted[loadAttemptLookupKey] = true;
-
-        try
-        {
-          static Config & config = Config::getInstance ();
-          attentionSound.load (config.getString ("PlaySoundAttention", ""));
-        }
-        catch (const megaglest_runtime_error & ex)
-        {
-          message (ex.what (),
-                   GlobalStaticFlags::getIsNonGraphicalModeEnabled (),
-                   tempDataLocation);
-        }
-      }
-
-      return &attentionSound;
-    }
-
-    StaticSound *CoreData::getNewServerSound ()
-    {
-      int loadAttemptLookupKey = tsyst_COUNT + 6;
-      if (itemLoadAttempted.find (loadAttemptLookupKey) ==
-          itemLoadAttempted.end ())
-      {
-
-        itemLoadAttempted[loadAttemptLookupKey] = true;
-
-        try
-        {
-          static Config & config = Config::getInstance ();
-          newServerSound.load (config.getString ("PlaySoundNewServer", ""));
-        }
-        catch (const megaglest_runtime_error & ex)
-        {
-          message (ex.what (),
-                   GlobalStaticFlags::getIsNonGraphicalModeEnabled (),
-                   tempDataLocation);
-        }
-      }
-
-      return &newServerSound;
-    }
-
-    StaticSound *CoreData::getHighlightSound ()
-    {
-      int loadAttemptLookupKey = tsyst_COUNT + 7;
-      if (itemLoadAttempted.find (loadAttemptLookupKey) ==
-          itemLoadAttempted.end ())
-      {
-
-        itemLoadAttempted[loadAttemptLookupKey] = true;
-
-        try
-        {
-          static Config & config = Config::getInstance ();
-          highlightSound.load (config.getString ("PlaySoundHighlight", ""));
-        }
-        catch (const megaglest_runtime_error & ex)
-        {
-          message (ex.what (),
-                   GlobalStaticFlags::getIsNonGraphicalModeEnabled (),
-                   tempDataLocation);
-        }
-      }
-
-      return &highlightSound;
-    }
     StaticSound *CoreData::getMarkerSound ()
     {
       int loadAttemptLookupKey = tsyst_COUNT + 8;

--- a/source/glest_game/global/core_data.cpp
+++ b/source/glest_game/global/core_data.cpp
@@ -65,9 +65,9 @@ namespace Glest
 
     // Sound effects
     // These variables are specified in the ini file
-    const string CoreData::sfxAttention = "PlaySoundAttention";
-    const string CoreData::sfxHighlight = "PlaySoundHighlight";
-    const string CoreData::sfxNewServer = "PlaySoundNewServer";
+    const string PlaySoundClip::sfxAttention = "PlaySoundAttention";
+    const string PlaySoundClip::sfxHighlight = "PlaySoundHighlight";
+    const string PlaySoundClip::sfxNewServer = "PlaySoundNewServer";
 
     CoreData & CoreData::getInstance ()
     {
@@ -727,31 +727,6 @@ namespace Glest
       }
 
       return &clickSoundC;
-    }
-
-    StaticSound *CoreData::getSound (const std::string& iniPlaySoundVal)
-    {
-      int loadAttemptLookupKey = tsyst_COUNT + 6;
-      if (itemLoadAttempted.find (loadAttemptLookupKey) ==
-          itemLoadAttempted.end ())
-      {
-
-        itemLoadAttempted[loadAttemptLookupKey] = true;
-
-        try
-        {
-          static Config & config = Config::getInstance ();
-          iniPlaySound.load (config.getString (iniPlaySoundVal, ""));
-        }
-        catch (const megaglest_runtime_error & ex)
-        {
-          message (ex.what (),
-                   GlobalStaticFlags::getIsNonGraphicalModeEnabled (),
-                   tempDataLocation);
-        }
-      }
-
-      return &iniPlaySound;
     }
 
     StaticSound *CoreData::getMarkerSound ()
@@ -2067,6 +2042,36 @@ namespace Glest
                                   __FUNCTION__, __LINE__);
 
       return fileWasFound;
+    }
+
+    PlaySoundClip::PlaySoundClip (void) {};
+
+    PlaySoundClip::~PlaySoundClip (void) {};
+
+    StaticSound *PlaySoundClip::getSound (const std::string& iniPlaySoundVal)
+    {
+      CoreData coreData;
+      int loadAttemptLookupKey = coreData.tsyst_COUNT + 6;
+      if (coreData.itemLoadAttempted.find (loadAttemptLookupKey) ==
+          coreData.itemLoadAttempted.end ())
+      {
+
+        coreData.itemLoadAttempted[loadAttemptLookupKey] = true;
+
+        try
+        {
+          static Config & config = Config::getInstance ();
+          iniPlaySound.load (config.getString (iniPlaySoundVal, ""));
+        }
+        catch (const megaglest_runtime_error & ex)
+        {
+          message (ex.what (),
+                   GlobalStaticFlags::getIsNonGraphicalModeEnabled (),
+                   tempDataLocation);
+        }
+      }
+
+      return &iniPlaySound;
     }
 
 // ================== PRIVATE ========================

--- a/source/glest_game/global/core_data.cpp
+++ b/source/glest_game/global/core_data.cpp
@@ -65,9 +65,9 @@ namespace Glest
 
     // Sound effects
     // These variables are specified in the ini file
-    static const std::string sfxAttention = "PlaySoundAttention";
-    static const std::string sfxHighlight = "PlaySoundHighlight";
-    static const std::string sfxNewServer = "PlaySoundNewServer";
+    const string CoreData::sfxAttention = "PlaySoundAttention";
+    const string CoreData::sfxHighlight = "PlaySoundHighlight";
+    const string CoreData::sfxNewServer = "PlaySoundNewServer";
 
     CoreData & CoreData::getInstance ()
     {

--- a/source/glest_game/global/core_data.cpp
+++ b/source/glest_game/global/core_data.cpp
@@ -68,6 +68,10 @@ namespace Glest
     const string PlaySoundClip::sfxAttention = "PlaySoundAttention";
     const string PlaySoundClip::sfxHighlight = "PlaySoundHighlight";
     const string PlaySoundClip::sfxNewServer = "PlaySoundNewServer";
+    const string PlaySoundClip::sfxMarker = "PlaySoundMarker";
+    const string PlaySoundClip::sfxMenuClickA = "PlaySoundMenuClickA";
+    const string PlaySoundClip::sfxMenuClickB = "PlaySoundMenuClickB";
+    const string PlaySoundClip::sfxMenuClickC = "PlaySoundMenuClickC";
 
     CoreData & CoreData::getInstance ()
     {
@@ -652,108 +656,20 @@ namespace Glest
 
     StaticSound *CoreData::getClickSoundA ()
     {
-      int loadAttemptLookupKey = tsyst_COUNT + 3;
-      if (itemLoadAttempted.find (loadAttemptLookupKey) ==
-          itemLoadAttempted.end ())
-      {
-
-        itemLoadAttempted[loadAttemptLookupKey] = true;
-
-        try
-        {
-          string data_path = getDataPath ();
-          clickSoundA.load (getGameCustomCoreDataPath (data_path,
-                                                       CORE_MENU_SOUND_PATH +
-                                                       "click_a.wav"));
-        }
-        catch (const megaglest_runtime_error & ex)
-        {
-          message (ex.what (),
-                   GlobalStaticFlags::getIsNonGraphicalModeEnabled (),
-                   tempDataLocation);
-        }
-      }
-      return &clickSoundA;
+      static PlaySoundClip snd;
+      return snd.getSound (snd.sfxMenuClickA);
     }
 
     StaticSound *CoreData::getClickSoundB ()
     {
-      int loadAttemptLookupKey = tsyst_COUNT + 4;
-      if (itemLoadAttempted.find (loadAttemptLookupKey) ==
-          itemLoadAttempted.end ())
-      {
+      static PlaySoundClip snd;
+      return snd.getSound (snd.sfxMenuClickB);
 
-        itemLoadAttempted[loadAttemptLookupKey] = true;
-
-        try
-        {
-          string data_path = getDataPath ();
-          clickSoundB.load (getGameCustomCoreDataPath (data_path,
-                                                       CORE_MENU_SOUND_PATH +
-                                                       "click_b.wav"));
-        }
-        catch (const megaglest_runtime_error & ex)
-        {
-          message (ex.what (),
-                   GlobalStaticFlags::getIsNonGraphicalModeEnabled (),
-                   tempDataLocation);
-        }
-      }
-
-      return &clickSoundB;
     }
     StaticSound *CoreData::getClickSoundC ()
     {
-      int loadAttemptLookupKey = tsyst_COUNT + 5;
-      if (itemLoadAttempted.find (loadAttemptLookupKey) ==
-          itemLoadAttempted.end ())
-      {
-
-        itemLoadAttempted[loadAttemptLookupKey] = true;
-
-        try
-        {
-          string data_path = getDataPath ();
-          clickSoundC.load (getGameCustomCoreDataPath (data_path,
-                                                       CORE_MENU_SOUND_PATH +
-                                                       "click_c.wav"));
-        }
-        catch (const megaglest_runtime_error & ex)
-        {
-          message (ex.what (),
-                   GlobalStaticFlags::getIsNonGraphicalModeEnabled (),
-                   tempDataLocation);
-        }
-      }
-
-      return &clickSoundC;
-    }
-
-    StaticSound *CoreData::getMarkerSound ()
-    {
-      int loadAttemptLookupKey = tsyst_COUNT + 8;
-      if (itemLoadAttempted.find (loadAttemptLookupKey) ==
-          itemLoadAttempted.end ())
-      {
-
-        itemLoadAttempted[loadAttemptLookupKey] = true;
-
-        try
-        {
-          string data_path = getDataPath ();
-          markerSound.load (getGameCustomCoreDataPath (data_path,
-                                                       CORE_MENU_SOUND_PATH +
-                                                       "sonar.wav"));
-        }
-        catch (const megaglest_runtime_error & ex)
-        {
-          message (ex.what (),
-                   GlobalStaticFlags::getIsNonGraphicalModeEnabled (),
-                   tempDataLocation);
-        }
-      }
-
-      return &markerSound;
+      static PlaySoundClip snd;
+      return snd.getSound (snd.sfxMenuClickC);
     }
 
     void CoreData::loadWaterSoundsIfRequired ()

--- a/source/glest_game/global/core_data.h
+++ b/source/glest_game/global/core_data.h
@@ -170,10 +170,6 @@ namespace Glest
       void cleanup ();
       void loadFonts ();
 
-      static const std::string sfxAttention;
-      static const std::string sfxHighlight;
-      static const std::string sfxNewServer;
-
       // Textures
       Texture2D *getTextureBySystemId (TextureSystemType type);
 
@@ -217,6 +213,10 @@ namespace Glest
       StaticSound *getSound (const std::string& iniPlaySoundVal);
       StaticSound *getMarkerSound ();
       StaticSound *getWaterSound ();
+
+      static const string sfxAttention;
+      static const string sfxHighlight;
+      static const string sfxNewServer;
 
       // Fonts
       Font2D *getDisplayFont () const

--- a/source/glest_game/global/core_data.h
+++ b/source/glest_game/global/core_data.h
@@ -67,9 +67,6 @@ namespace Glest
       StaticSound clickSoundB;
       StaticSound clickSoundC;
       StaticSound iniPlaySound;
-      StaticSound attentionSound;
-      StaticSound newServerSound;
-      StaticSound highlightSound;
       StaticSound markerSound;
       SoundContainer waterSounds;
 
@@ -173,6 +170,10 @@ namespace Glest
       void cleanup ();
       void loadFonts ();
 
+      static const std::string sfxAttention;
+      static const std::string sfxHighlight;
+      static const std::string sfxNewServer;
+
       // Textures
       Texture2D *getTextureBySystemId (TextureSystemType type);
 
@@ -214,9 +215,6 @@ namespace Glest
       StaticSound *getClickSoundB ();
       StaticSound *getClickSoundC ();
       StaticSound *getSound (const std::string& iniPlaySoundVal);
-      StaticSound *getAttentionSound ();
-      StaticSound *getNewServerSound ();
-      StaticSound *getHighlightSound ();
       StaticSound *getMarkerSound ();
       StaticSound *getWaterSound ();
 

--- a/source/glest_game/global/core_data.h
+++ b/source/glest_game/global/core_data.h
@@ -64,10 +64,6 @@ namespace Glest
 
       StrSound introMusic;
       StrSound menuMusic;
-      StaticSound clickSoundA;
-      StaticSound clickSoundB;
-      StaticSound clickSoundC;
-      StaticSound markerSound;
       SoundContainer waterSounds;
 
       Texture2D *logoTexture;
@@ -207,10 +203,17 @@ namespace Glest
       StrSound *getIntroMusic ();
       StrSound *getMenuMusic ();
 
+      // When issue #63 was done
+      // <https://github.com/ZetaGlest/zetaglest-source/issues/63>
+      // and the PlaySoundFile class was created,
+      // these functions were kept because they were being called from many
+      // different places in the code base. Rather than trying to change
+      // all those locations, I made these three into "wrapper" functions.
+      // -andy5995 2018-02-22
       StaticSound *getClickSoundA ();
       StaticSound *getClickSoundB ();
       StaticSound *getClickSoundC ();
-      StaticSound *getMarkerSound ();
+
       StaticSound *getWaterSound ();
 
       // Fonts
@@ -363,6 +366,10 @@ namespace Glest
             static const string sfxAttention;
             static const string sfxHighlight;
             static const string sfxNewServer;
+            static const string sfxMarker;
+            static const string sfxMenuClickA;
+            static const string sfxMenuClickB;
+            static const string sfxMenuClickC;
             PlaySoundClip();
             ~PlaySoundClip();
 

--- a/source/glest_game/global/core_data.h
+++ b/source/glest_game/global/core_data.h
@@ -58,6 +58,7 @@ namespace Glest
 
     class CoreData
     {
+    friend class PlaySoundClip;
     private:
       std::map < int, bool > itemLoadAttempted;
 
@@ -66,7 +67,6 @@ namespace Glest
       StaticSound clickSoundA;
       StaticSound clickSoundB;
       StaticSound clickSoundC;
-      StaticSound iniPlaySound;
       StaticSound markerSound;
       SoundContainer waterSounds;
 
@@ -210,13 +210,8 @@ namespace Glest
       StaticSound *getClickSoundA ();
       StaticSound *getClickSoundB ();
       StaticSound *getClickSoundC ();
-      StaticSound *getSound (const std::string& iniPlaySoundVal);
       StaticSound *getMarkerSound ();
       StaticSound *getWaterSound ();
-
-      static const string sfxAttention;
-      static const string sfxHighlight;
-      static const string sfxNewServer;
 
       // Fonts
       Font2D *getDisplayFont () const
@@ -355,8 +350,23 @@ namespace Glest
                                               string fontType,
                                               string fontTypeFamily,
                                               string fontUniqueKey);
+
+
     };
 
+      class PlaySoundClip
+    {
+      private:
+            StaticSound iniPlaySound;
+      public:
+            StaticSound *getSound (const std::string& iniPlaySoundVal);
+            static const string sfxAttention;
+            static const string sfxHighlight;
+            static const string sfxNewServer;
+            PlaySoundClip();
+            ~PlaySoundClip();
+
+      };
 }}                              //end namespace
 
 #endif

--- a/source/glest_game/menu/menu_state_connected_game.cpp
+++ b/source/glest_game/menu/menu_state_connected_game.cpp
@@ -6344,7 +6344,7 @@ namespace Glest
             {
               soundConnectionCount = currentConnectionCount;
               SoundRenderer::getInstance ().
-                playFx (CoreData::getInstance ().getAttentionSound ());
+                playFx (CoreData::getInstance ().getSound (CoreData::sfxAttention));
 //switch on music again!!
               Config & config = Config::getInstance ();
               float

--- a/source/glest_game/menu/menu_state_connected_game.cpp
+++ b/source/glest_game/menu/menu_state_connected_game.cpp
@@ -6343,8 +6343,9 @@ namespace Glest
             if (currentConnectionCount > soundConnectionCount)
             {
               soundConnectionCount = currentConnectionCount;
+              PlaySoundClip snd;
               SoundRenderer::getInstance ().
-                playFx (CoreData::getInstance ().getSound (CoreData::sfxAttention));
+                playFx (snd.getSound (snd.sfxAttention));
 //switch on music again!!
               Config & config = Config::getInstance ();
               float

--- a/source/glest_game/menu/menu_state_connected_game.cpp
+++ b/source/glest_game/menu/menu_state_connected_game.cpp
@@ -6343,7 +6343,7 @@ namespace Glest
             if (currentConnectionCount > soundConnectionCount)
             {
               soundConnectionCount = currentConnectionCount;
-              PlaySoundClip snd;
+              static PlaySoundClip snd;
               SoundRenderer::getInstance ().
                 playFx (snd.getSound (snd.sfxAttention));
 //switch on music again!!

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -4674,7 +4674,7 @@ namespace Glest
         if (currentConnectionCount > soundConnectionCount)
         {
           soundConnectionCount = currentConnectionCount;
-          PlaySoundClip snd;
+          static PlaySoundClip snd;
           SoundRenderer::getInstance ().
             playFx (snd.getSound (snd.sfxAttention));
 //switch on music again!!

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -4674,8 +4674,9 @@ namespace Glest
         if (currentConnectionCount > soundConnectionCount)
         {
           soundConnectionCount = currentConnectionCount;
+          PlaySoundClip snd;
           SoundRenderer::getInstance ().
-            playFx (CoreData::getInstance ().getSound (CoreData::sfxAttention));
+            playFx (snd.getSound (snd.sfxAttention));
 //switch on music again!!
           Config & config = Config::getInstance ();
           float configVolume = (config.getInt ("SoundVolumeMusic") / 100.f);

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -4675,7 +4675,7 @@ namespace Glest
         {
           soundConnectionCount = currentConnectionCount;
           SoundRenderer::getInstance ().
-            playFx (CoreData::getInstance ().getAttentionSound ());
+            playFx (CoreData::getInstance ().getSound (CoreData::sfxAttention));
 //switch on music again!!
           Config & config = Config::getInstance ();
           float configVolume = (config.getInt ("SoundVolumeMusic") / 100.f);

--- a/source/glest_game/menu/menu_state_masterserver.cpp
+++ b/source/glest_game/menu/menu_state_masterserver.cpp
@@ -553,9 +553,8 @@ namespace Glest
           string helpSTr = szBuf;
           if (helpSTr.find (currentIrcNick) != string::npos)
           {
-            CoreData & coreData = CoreData::getInstance ();
             SoundRenderer & soundRenderer = SoundRenderer::getInstance ();
-            PlaySoundClip snd;
+            static PlaySoundClip snd;
             soundRenderer.playFx (snd.getSound (snd.sfxHighlight));
           }
           consoleIRC.addLine (szBuf);

--- a/source/glest_game/menu/menu_state_masterserver.cpp
+++ b/source/glest_game/menu/menu_state_masterserver.cpp
@@ -555,8 +555,8 @@ namespace Glest
           {
             CoreData & coreData = CoreData::getInstance ();
             SoundRenderer & soundRenderer = SoundRenderer::getInstance ();
-
-            soundRenderer.playFx (coreData.getSound (CoreData::sfxHighlight));
+            PlaySoundClip snd;
+            soundRenderer.playFx (snd.getSound (snd.sfxHighlight));
           }
           consoleIRC.addLine (szBuf);
         }
@@ -1216,7 +1216,8 @@ namespace Glest
 
       if (playServerFoundSound)
       {
-        SoundRenderer::getInstance ().playFx (CoreData::getInstance ().getSound (CoreData::sfxNewServer));
+        static PlaySoundClip snd;
+        SoundRenderer::getInstance ().playFx (snd.getSound (snd.sfxNewServer));
 
         //switch on music again!!
         Config & config = Config::getInstance ();

--- a/source/glest_game/menu/menu_state_masterserver.cpp
+++ b/source/glest_game/menu/menu_state_masterserver.cpp
@@ -556,7 +556,7 @@ namespace Glest
             CoreData & coreData = CoreData::getInstance ();
             SoundRenderer & soundRenderer = SoundRenderer::getInstance ();
 
-            soundRenderer.playFx (coreData.getHighlightSound ());
+            soundRenderer.playFx (coreData.getSound (CoreData::sfxHighlight));
           }
           consoleIRC.addLine (szBuf);
         }
@@ -1217,7 +1217,7 @@ namespace Glest
       if (playServerFoundSound)
       {
         SoundRenderer::getInstance ().playFx (CoreData::getInstance ().
-                                              getNewServerSound ());
+                                              getSound (CoreData::sfxNewServer));
         //switch on music again!!
         Config & config = Config::getInstance ();
         float configVolume = (config.getInt ("SoundVolumeMusic") / 100.f);

--- a/source/glest_game/world/unit_updater.cpp
+++ b/source/glest_game/world/unit_updater.cpp
@@ -1,13 +1,25 @@
-// ==============================================================
-//	This file is part of Glest (www.glest.org)
 //
-//	Copyright (C) 2001-2008 Martiño Figueroa
+//      unit_updater.cpp: game setup menu as it appears to
+//      to the host
 //
-//	You can redistribute this code and/or modify it under
-//	the terms of the GNU General Public License as published
-//	by the Free Software Foundation; either version 2 of the
-//	License, or (at your option) any later version
-// ==============================================================
+//      This file is part of ZetaGlest <https://github.com/ZetaGlest>
+//
+//      Copyright (C) 2018  The ZetaGlest team
+//
+//      ZetaGlest is a fork of MegaGlest <https://megaglest.org>
+//
+//      This program is free software: you can redistribute it and/or modify
+//      it under the terms of the GNU General Public License as published by
+//      the Free Software Foundation, either version 3 of the License, or
+//      (at your option) any later version.
+//
+//      This program is distributed in the hope that it will be useful,
+//      but WITHOUT ANY WARRANTY; without even the implied warranty of
+//      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//      GNU General Public License for more details.
+//
+//      You should have received a copy of the GNU General Public License
+//      along with this program.  If not, see <https://www.gnu.org/licenses/>
 
 #include "unit_updater.h"
 
@@ -3131,7 +3143,7 @@ bool UnitUpdater::unitOnRange(Unit *unit, int range, Unit **rangedPtr,
 
 	    		if(world->getAttackWarningsEnabled() == true) {
 
-	    			SoundRenderer::getInstance().playFx(CoreData::getInstance().getAttentionSound(),true);
+	    			SoundRenderer::getInstance().playFx(CoreData::getInstance().getSound(CoreData::sfxAttention),true);
 	    			world->addAttackEffects(enemyUnit);
 	    		}
 	    	}

--- a/source/glest_game/world/unit_updater.cpp
+++ b/source/glest_game/world/unit_updater.cpp
@@ -3142,8 +3142,9 @@ bool UnitUpdater::unitOnRange(Unit *unit, int range, Unit **rangedPtr,
 	    		attackWarnings.push_back(awd);
 
 	    		if(world->getAttackWarningsEnabled() == true) {
+						static PlaySoundClip snd;
 
-	    			SoundRenderer::getInstance().playFx(CoreData::getInstance().getSound(CoreData::sfxAttention),true);
+	    			SoundRenderer::getInstance().playFx(snd.getSound (snd.sfxAttention),true);
 	    			world->addAttackEffects(enemyUnit);
 	    		}
 	    	}

--- a/source/glest_game/world/unit_updater.h
+++ b/source/glest_game/world/unit_updater.h
@@ -1,13 +1,25 @@
-// ==============================================================
-//	This file is part of Glest (www.glest.org)
 //
-//	Copyright (C) 2001-2008 Martiño Figueroa
+//      unit_updater.h: game setup menu as it appears to
+//      to the host
 //
-//	You can redistribute this code and/or modify it under
-//	the terms of the GNU General Public License as published
-//	by the Free Software Foundation; either version 2 of the
-//	License, or (at your option) any later version
-// ==============================================================
+//      This file is part of ZetaGlest <https://github.com/ZetaGlest>
+//
+//      Copyright (C) 2018  The ZetaGlest team
+//
+//      ZetaGlest is a fork of MegaGlest <https://megaglest.org>
+//
+//      This program is free software: you can redistribute it and/or modify
+//      it under the terms of the GNU General Public License as published by
+//      the Free Software Foundation, either version 3 of the License, or
+//      (at your option) any later version.
+//
+//      This program is distributed in the hope that it will be useful,
+//      but WITHOUT ANY WARRANTY; without even the implied warranty of
+//      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//      GNU General Public License for more details.
+//
+//      You should have received a copy of the GNU General Public License
+//      along with this program.  If not, see <https://www.gnu.org/licenses/>
 
 #ifndef _GLEST_GAME_UNITUPDATER_H_
 #define _GLEST_GAME_UNITUPDATER_H_


### PR DESCRIPTION
Everything compiles but doesn't link

```
[ 82%] Linking CXX executable ../../../zetaglest
CMakeFiles/zetaglest.dir/game/chat_manager.cpp.o: In function
`Glest::Game::ChatManager::updateNetwork()':
/home/andy/src/ZetaGlest/zetaglest-source/source/glest_game/game/chat_manager.cpp:797:
undefined reference to `Glest::Game::CoreData::sfxHighlight[abi:cxx11]'
CMakeFiles/zetaglest.dir/menu/menu_state_connected_game.cpp.o: In
function `Glest::Game::MenuStateConnectedGame::update()':
/home/andy/src/ZetaGlest/zetaglest-source/source/glest_game/menu/menu_state_connected_game.cpp:6347:
undefined reference to `Glest::Game::CoreData::sfxAttention[abi:cxx11]'
CMakeFiles/zetaglest.dir/menu/menu_state_custom_game.cpp.o: In function
`Glest::Game::MenuStateCustomGame::update()':
/home/andy/src/ZetaGlest/zetaglest-source/source/glest_game/menu/menu_state_custom_game.cpp:4678:
undefined reference to `Glest::Game::CoreData::sfxAttention[abi:cxx11]'
CMakeFiles/zetaglest.dir/menu/menu_state_masterserver.cpp.o: In function
`Glest::Game::MenuStateMasterserver::IRC_CallbackEvent(Shared::PlatformCommon::IRCEventType,
char const*, char const**, unsigned int)':
/home/andy/src/ZetaGlest/zetaglest-source/source/glest_game/menu/menu_state_masterserver.cpp:559:
undefined reference to `Glest::Game::CoreData::sfxHighlight[abi:cxx11]'
CMakeFiles/zetaglest.dir/menu/menu_state_masterserver.cpp.o: In function
`Glest::Game::MenuStateMasterserver::update()':
/home/andy/src/ZetaGlest/zetaglest-source/source/glest_game/menu/menu_state_masterserver.cpp:1219:
undefined reference to `Glest::Game::CoreData::sfxNewServer[abi:cxx11]'
CMakeFiles/zetaglest.dir/world/unit_updater.cpp.o: In function
`Glest::Game::UnitUpdater::unitOnRange(Glest::Game::Unit*, int,
Glest::Game::Unit**, Glest::Game::AttackSkillType const*, bool)':
/home/andy/src/ZetaGlest/zetaglest-source/source/glest_game/world/unit_updater.cpp:3146:
undefined reference to `Glest::Game::CoreData::sfxAttention[abi:cxx11]'
collect2: error: ld returned 1 exit status
source/glest_game/CMakeFiles/zetaglest.dir/build.make:2363: recipe for
target '../zetaglest' failed
make[2]: *** [../zetaglest] Error 1
CMakeFiles/Makefile2:195: recipe for target
'source/glest_game/CMakeFiles/zetaglest.dir/all' failed
make[1]: *** [source/glest_game/CMakeFiles/zetaglest.dir/all] Error 2
Makefile:105: recipe for target 'all' failed
make: *** [all] Error 2
ERROR: MAKE failed.
```