### PR TITLE
Clang gets confused when the derived has same methods

### DIFF
--- a/source/glest_game/facilities/components.h
+++ b/source/glest_game/facilities/components.h
@@ -93,7 +93,7 @@ public:
 	static bool saveAllCustomProperties(std::string containerName);
 	virtual bool saveCustomProperties(std::string containerName);
 
-	virtual void init(int x, int y, int w, int h);
+	void init(int x, int y, int w, int h);
 
 	string getContainerName() const { return containerName; }
 	string getInstanceName() const { return instanceName; }
@@ -128,7 +128,7 @@ public:
 	static void reloadFontsForRegisterGraphicComponents(std::string containerName);
 
     virtual bool mouseMove(int x, int y);
-    virtual bool mouseClick(int x, int y);
+    bool mouseClick(int x, int y);
 
 	static void update();
 	static void resetFade();

--- a/source/glest_game/types/upgrade_type.h
+++ b/source/glest_game/types/upgrade_type.h
@@ -285,7 +285,7 @@ namespace Glest
 	 * @param upgradename Unique identifier for the upgrade.
 	 */
 
-      virtual void load (const XmlNode * upgradeNode, string upgradename);
+      void load (const XmlNode * upgradeNode, string upgradename);
 
         /**
 	 * Creates a string representation of the upgrade. All stat boosts are detailed on their own line


### PR DESCRIPTION
with different signatures than base's virtual.
But since the derived do not reimplement them, the base
do not need to be virtual.