### PR TITLE
Attempt to fix OOS bug in windows-linux games.

### DIFF
--- a/source/glest_game/type_instances/faction.cpp
+++ b/source/glest_game/type_instances/faction.cpp
@@ -450,7 +450,10 @@ namespace Glest
             //bool sortedUnitsAllowed = config.getBool("AllowGroupedUnitCommands","true");
             //bool sortedUnitsAllowed = false;
             //if(sortedUnitsAllowed == true) {
-            this->faction->sortUnitsByCommandGroups ();
+
+            /// TODO: Why does this cause and OOS?
+            //this->faction->sortUnitsByCommandGroups ();
+
             //}
 
             codeLocation = "8";


### PR DESCRIPTION
The function commented out by my commit was (possibly accidentally) enabled during cleanups on MegaGlest.
Me and vibe tested a linux-windows game with this code disabled and got no OOS'es. However, we only tested on version 26581a77d2cb4538d718842c82063c2ecc36b31a , so there may still be more OOS bugs.

Also, I have no idea why this was causing the OOS. #26 