### PR TITLE
ai:revert AI enhancement

### DIFF
--- a/source/glest_game/ai/ai.h
+++ b/source/glest_game/ai/ai.h
@@ -316,7 +316,7 @@ namespace
         minMinWarriorsExpandCpuUltra = 3;
         minMinWarriorsExpandCpuNormal = 3;
         maxMinWarriors = 20;
-        maxExpansions = 20;
+        maxExpansions = 5;
         villageRadius = 15;
         scoutResourceRange = 20;
         minWorkerAttackersHarvesting = 3;

--- a/source/glest_game/ai/ai_rule.cpp
+++ b/source/glest_game/ai/ai_rule.cpp
@@ -590,7 +590,7 @@ namespace
               //workers
               if (workerCount < 5)
                 ai->addTask (new ProduceTask (ucWorker));
-              if (workerCount < 100)
+              if (workerCount < 10)
                 ai->addTask (new ProduceTask (ucWorker));
               if (workerRatio < 0.20)
                 ai->addTask (new ProduceTask (ucWorker));

--- a/source/glest_game/ai/ai_rule.h
+++ b/source/glest_game/ai/ai_rule.h
@@ -109,7 +109,7 @@ namespace
       getTestInterval () const
       {
         return
-          1000;
+          2000;
       }
       virtual string
       getName () const
@@ -459,7 +459,7 @@ namespace
       getTestInterval () const
       {
         return
-          100;
+          2000;
       }
       virtual string
       getName () const


### PR DESCRIPTION
@Jammyjamjamman suspects the AI patch from commit
https://github.com/ZetaGlest/zetaglest-source/commit/464860aa023e4089f4c6f108e019d66d60052581#diff-d96c21449fc203a306589b5bd1f8aaa1
may be causing extra lag when playing mp with Windows clients.

This patch reverts most of that commit. Max expansions I set to 5, the
MG setting was 2.

If this fixes the lag, then we can consider looking at making these
changes again, but one at a time, making sure lag isn't a result before
making more changes.

Anyone can review this to learn some of the code, but I'd like to hear
feedback from Jammy before finally merging.