### PR TITLE
.travis.yml:remove "Tr_default"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ matrix:
           apt:
             packages:
             - libsdl2-dev
+      env: Tr_Compiler_Version="7"
+      # https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
+      dist: trusty # broken compiler on 12.04
     - os: linux
       compiler: clang
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,6 @@ matrix:
           apt:
             packages:
             - libsdl2-dev
-      env: Tr_Compiler_Version="7"
-      # https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
-      dist: trusty # broken compiler on 12.04
-    - os: linux
-      compiler: gcc
-      addons:
-          apt:
-            packages:
-            - libsdl2-dev
-      env: Tr_Compiler_Version="default"
-      dist: trusty
     - os: linux
       compiler: clang
       addons:


### PR DESCRIPTION
This needs updating. I don't know yet how best to proceed.
https://github.com/ZetaGlest/zetaglest-source/blob/develop/.travis-before_install.sh

This patch is to help fix the broken build shown at
https://travis-ci.org/ZetaGlest/zetaglest-source/builds/378943044

There's some info in this IRC log that might be helpful. Apparently someone had a similar problem.

https://godot.eska.me/irc-logs/devel/2017-04-26.log

The latest version of Ubuntu is 18.04