### PR TITLE
CMakeLists.txt:add gnu option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,14 @@ matrix:
       # https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
       dist: trusty # broken compiler on 12.04
     - os: linux
+      compiler: gcc
+      addons:
+          apt:
+            packages:
+            - libsdl2-dev
+      env: Tr_Compiler_Version="default"
+      dist: trusty
+    - os: linux
       compiler: clang
       addons:
           apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX OR MINGW)
 
     # GCC specific Compiler Options
     ELSE()
-        ADD_DEFINITIONS("-frounding-math -fsignaling-nans")
+        ADD_DEFINITIONS("-std=gnu++11 -frounding-math -fsignaling-nans")
 
 #                IF(NOT MINGW)
 #                        set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -rdynamic")


### PR DESCRIPTION
Enabling gnu+11 extensions fixes the travis build issue mentioned below.

(related:
https://github.com/ZetaGlest/zetaglest-source/commit/069f36ee1f38ddcbc9c294952c6f56a77ede30a9)

The output from travis was

```home/travis/build/ZetaGlest/zetaglest-source/source/glest_game/game/script_manager.cpp:3118:52: error: ‘Glest::Game::Field’ is not a class or namespace
       unit->setCurrField(value == 1 ? Glest::Game::Field::fAir : Glest::Game::Field::fLand);
                                                    ^
/home/travis/build/ZetaGlest/zetaglest-source/source/glest_game/game/script_manager.cpp:3118:79: error: ‘Glest::Game::Field’ is not a class or namespace
       unit->setCurrField(value == 1 ? Glest::Game::Field::fAir : Glest::Game::Field::fLand);```