### PR TITLE
Disable Nagle's algorithm for better net performance.

### DIFF
--- a/source/shared_lib/sources/platform/posix/socket.cpp
+++ b/source/shared_lib/sources/platform/posix/socket.cpp
@@ -68,7 +68,7 @@ using namespace Shared::Util;
 namespace Shared {
 	namespace Platform {
 
-		bool Socket::disableNagle = false;
+		bool Socket::disableNagle = true;
 		int Socket::DEFAULT_SOCKET_SENDBUF_SIZE = -1;
 		int Socket::DEFAULT_SOCKET_RECVBUF_SIZE = -1;
 		string Socket::host_name = "";


### PR DESCRIPTION
Nagle's algorithm is bad for network games performance, yet appears to be enabled in ZetaGlest. Not sure if this will have any effect, because I still don't know how the code works. This should be tested with a cross-platform game before merging.