### PR TITLE
Fixes problem when choosing the faction of an AI

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,6 +10,7 @@ which includes the _MegaGlest_ commit log.
 
 * [Andy Alt](https://github.com/andy5995)
 * [James Sherratt](https://github.com/Jammyjamjamman)
+* [João Marcos](https://github.com/JoaoMarcosCSilva)
 
 ### php || mysql
 

--- a/source/glest_game/facilities/components.h
+++ b/source/glest_game/facilities/components.h
@@ -370,7 +370,7 @@ namespace Glest {
 			static const int defH;
 			static const int defW;
 
-		private:
+		protected:
 			GraphicButton graphButton1, graphButton2;
 			vector<string> items;
 			vector<string> translated_items;

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -77,7 +77,6 @@ namespace Glest {
 		void GraphicListBoxFactions::addInformation(MenuStateCustomGame *menu, int index) {
 			this->menu = menu;
 			this->index = index;
-			printf("Index = %d\n", index);
 		}
 		bool GraphicListBoxFactions::mouseClick(int x, int y, string advanceToItemStartingWith) {
 			if (this->getVisible() == false) {

--- a/source/glest_game/menu/menu_state_custom_game.cpp
+++ b/source/glest_game/menu/menu_state_custom_game.cpp
@@ -68,7 +68,117 @@ namespace Glest {
 				s = formatString(s);
 			}
 		};
+		// =====================================================
+		//      class GraphicListBoxFactions
+		// =====================================================
 
+		GraphicListBoxFactions::GraphicListBoxFactions(const std::string &containerName, const std::string &objName) : GraphicListBox::GraphicListBox(containerName, objName) {}
+
+		void GraphicListBoxFactions::addInformation(MenuStateCustomGame *menu, int index) {
+			this->menu = menu;
+			this->index = index;
+			printf("Index = %d\n", index);
+		}
+		bool GraphicListBoxFactions::mouseClick(int x, int y, string advanceToItemStartingWith) {
+			if (this->getVisible() == false) {
+				return false;
+			}
+
+			if (!items.empty()) {
+
+				bool b1 = graphButton1.mouseClick(x, y);
+				bool b2 = graphButton2.mouseClick(x, y);
+
+				int superj = selectedItemIndex;
+
+				if (b1) {
+					bool bFound = false;
+					if (advanceToItemStartingWith != "") {
+						for (int i = selectedItemIndex - 1; i >= 0; --i) {
+							string item = items[i];
+							if ((int)translated_items.size() > i) item = translated_items[i];
+							if (StartsWith(toLower(item), toLower(advanceToItemStartingWith)) == true) {
+								bFound = true;
+								selectedItemIndex = i;
+								break;
+							}
+						}
+						if (bFound == false) {
+							for (int i = (int)items.size() - 1; i >= selectedItemIndex; --i) {
+								string item = items[i];
+								if ((int)translated_items.size() > i) item = translated_items[i];
+								if (StartsWith(toLower(item), toLower(advanceToItemStartingWith)) == true) {
+									bFound = true;
+									selectedItemIndex = i;
+									break;
+								}
+							}
+						}
+					}
+					if (bFound == false) {
+						--selectedItemIndex %= items.size();
+
+						int type = 0;
+						std::string faction = "";
+						if (menu != NULL) {
+							type = (menu->listBoxControls)[index].getSelectedItemIndex();
+							faction = menu->factionFiles[getSelectedItemIndex()];
+						}
+						if (menu != NULL
+							&& faction == formatString(GameConstants::OBSERVER_SLOTNAME)
+							&& (type == ctCpuEasy || type == ctCpu || type == ctCpuUltra || type == ctCpuZeta)) {
+							--selectedItemIndex %= items.size();
+						}
+
+
+					}
+
+				}
+				else if (b2) {
+					bool bFound = false;
+					if (advanceToItemStartingWith != "") {
+						for (int i = selectedItemIndex + 1; i < (int)items.size(); ++i) {
+							string item = items[i];
+							if ((int)translated_items.size() > i) item = translated_items[i];
+							if (StartsWith(toLower(item), toLower(advanceToItemStartingWith)) == true) {
+								bFound = true;
+								selectedItemIndex = i;
+								break;
+							}
+						}
+						if (bFound == false) {
+							for (int i = 0; i <= selectedItemIndex; ++i) {
+								string item = items[i];
+								if ((int)translated_items.size() > i) item = translated_items[i];
+								if (StartsWith(toLower(item), toLower(advanceToItemStartingWith)) == true) {
+									bFound = true;
+									selectedItemIndex = i;
+									break;
+								}
+							}
+						}
+					}
+					if (bFound == false) {
+						++selectedItemIndex %= items.size();
+
+						int type = 0;
+						std::string faction = "";
+						if (menu != NULL) {
+							type = (menu->listBoxControls)[index].getSelectedItemIndex();
+							faction = menu->factionFiles[getSelectedItemIndex()];
+						}
+						if (menu != NULL
+							&& faction == formatString(GameConstants::OBSERVER_SLOTNAME)
+							&& (type == ctCpuEasy || type == ctCpu || type == ctCpuUltra || type == ctCpuZeta)) {
+							++selectedItemIndex %= items.size();
+						}
+					}
+				}
+				setText(getSelectedItem());
+				return b1 || b2;
+			}
+			return false;
+		}
 		// =====================================================
 		//      class MenuStateCustomGame
 		// =====================================================
@@ -1979,7 +2089,7 @@ namespace Glest {
 									}
 
 									//printf("checkControTypeClicked = %d selectedControlItemIndex = %d i = %d\n",checkControTypeClicked,selectedControlItemIndex,i);
-
+									listBoxFactions[i].addInformation(this, i);
 									if (selectedControlItemIndex != ctHuman &&
 										checkControTypeClicked == true &&
 										listBoxControls[i].mouseClick(x, y)) {
@@ -5795,6 +5905,7 @@ namespace Glest {
 								//printf("DONE Setting scenario faction i = %d [ %s]\n",i,scenarioInfo.factionTypeNames[i].c_str());
 
 								// Disallow CPU players to be observers
+								listBoxFactions[i].addInformation(this, i);
 								if (factionFiles
 									[listBoxFactions[i].getSelectedItemIndex()] ==
 									formatString(GameConstants::OBSERVER_SLOTNAME)

--- a/source/glest_game/menu/menu_state_custom_game.h
+++ b/source/glest_game/menu/menu_state_custom_game.h
@@ -46,19 +46,33 @@ namespace Glest {
 		class SwitchSetupRequest;
 		class ServerInterface;
 		class TechTree;
+		class MenuStateCustomGame;
 
 		enum ParentMenuState {
 			pNewGame,
 			pMasterServer,
 			pLanGame
 		};
+		// =====================================================
+		//      class GraphicListBoxFactions
+        // =====================================================
 
+		class GraphicListBoxFactions : public GraphicListBox {
+		private:
+			MenuStateCustomGame * menu;
+			int index;
+		public:
+			GraphicListBoxFactions(const std::string &containerName = "", const std::string &objName = "");
+			void addInformation(MenuStateCustomGame* m, int i);
+			bool mouseClick(int x, int y, string advanceToItemStartingWith);
+		};
 		// ===============================
 		//      class MenuStateCustomGame
 		// ===============================
 
 		class MenuStateCustomGame :
 			public MenuState, public SimpleTaskCallbackInterface {
+			friend class GraphicListBoxFactions;
 		private:
 			GraphicButton buttonReturn;
 			GraphicButton buttonPlayNow;
@@ -93,7 +107,7 @@ namespace Glest {
 			GraphicListBox listBoxControls[GameConstants::maxPlayers];
 			GraphicButton buttonBlockPlayers[GameConstants::maxPlayers];
 			GraphicListBox listBoxRMultiplier[GameConstants::maxPlayers];
-			GraphicListBox listBoxFactions[GameConstants::maxPlayers];
+			GraphicListBoxFactions listBoxFactions[GameConstants::maxPlayers];
 			GraphicListBox listBoxTeams[GameConstants::maxPlayers];
 			GraphicLabel labelNetStatus[GameConstants::maxPlayers];
 			MapInfo mapInfo;


### PR DESCRIPTION
This fixes the problem when choosing the faction of an AI in the custom game screen (Issue #184)
The problem was happening because the menu_state_custom_game automatically changed the faction selection from *Observed* to index 0 (Brisith/ Magic), since AI can't be an Observer.
To fix that, I created a new class GraphicListBoxFactions that works exactly the same as the normal GraphicListBox, but every time the user press one of the buttons it checks if it currently represents an AI Observer, and then changes the selection accordingly.