### PR TITLE
cmake:add c++11 flag

### DIFF
--- a/source/shared_lib/CMakeLists.txt
+++ b/source/shared_lib/CMakeLists.txt
@@ -4,6 +4,7 @@
 OPTION(FORCE_EMBEDDED_LIBS "Force use of embedded libraries' code." OFF)
 
 add_definitions("-DDATADIR=${INSTALL_DIR_DATA}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 if(WANT_USE_STREFLOP)
 	# IMPORTANT: should come BEFORE finding packages

--- a/source/shared_lib/CMakeLists.txt
+++ b/source/shared_lib/CMakeLists.txt
@@ -4,6 +4,9 @@
 OPTION(FORCE_EMBEDDED_LIBS "Force use of embedded libraries' code." OFF)
 
 add_definitions("-DDATADIR=${INSTALL_DIR_DATA}")
+
+# On Travis, the build fails on osx and Ubuntu trusty using
+# clang 5.0 unless the -std=c++11 if used
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 if(WANT_USE_STREFLOP)

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -7,10 +7,9 @@ SET(TARGET_NAME "zetaglest_tests")
 IF(BUILD_ZETAGLEST_TESTS)
 	MESSAGE(STATUS "Build ${TARGET_NAME} = YES")
 
-# The tests fail on Travis with clang on osx because of the use of "bind"
-	if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
-	endif()
+	# On Travis, the build fails on osx and Ubuntu trusty using
+	# clang 5.0 unless the -std=c++11 if used
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 	INCLUDE (CheckIncludeFiles)
 


### PR DESCRIPTION
to prevent errors such as this:

https://travis-ci.org/ZetaGlest/zetaglest-source/builds/436849785