### PR TITLE
README.md:remove coverity badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/ZetaGlest/zetaglest-source.svg?branch=develop)](https://travis-ci.org/ZetaGlest/zetaglest-source)
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/16606/badge.svg)](https://scan.coverity.com/projects/zetaglest)
 
 **This is the game engine source code repository.**
 

--- a/mk/linux/coverity-scan.txt
+++ b/mk/linux/coverity-scan.txt
@@ -1,8 +1,0 @@
-Coverity builds won't need to be submitted very often.
-
-The instructions are at https://scan.coverity.com/download?tab=cxx
-
-The main commands to run after the prerequisites are met are:
-
-        cov-build --dir cov-int make
-        tar czf zetaglest.tgz cov-build


### PR DESCRIPTION
Coverity's broken, unable to access "defects" page or dashboard, support
non-responsive, documentation out of date, doesn't provide an option to
remove project

https://stackoverflow.com/questions/34520441/how-to-remove-a-project-from-coverity-scan

[skip ci]