### PR TITLE
skip using the CMakeLists.txt in mk/macos, add fontconfig to osx deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ git:
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./.travis-before_install.sh "$CC" "$Tr_Compiler_Version"; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install sdl2 lua freetype ftgl libogg glew libvorbis cppunit glib fribidi miniupnpc wxmac; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install sdl2 lua fontconfig freetype ftgl libogg glew libvorbis cppunit glib fribidi miniupnpc wxmac; fi
     # ^ not on travis also needed are: cmake + pkgconfig + xquartz (find by "search") + (maybe) git + (maybe) bash
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew outdated cmake || brew upgrade cmake; brew outdated pkgconfig || brew upgrade pkgconfig; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew link --force gettext; fi

--- a/BUILD.md
+++ b/BUILD.md
@@ -97,7 +97,7 @@ gcc g++ cmake libsdl2-dev libalut-dev libgl1-mesa-dev libglu1-mesa-dev libvorbis
 
 You can install the dependencies with [brew](https://brew.sh/)
 
-    brew install sdl2 lua freetype ftgl libogg glew libvorbis cppunit glib fribidi miniupnpc wxmac
+    brew install sdl2 lua fontconfig freetype ftgl libogg glew libvorbis cppunit glib fribidi miniupnpc wxmac
     brew outdated cmake || brew upgrade cmake; brew outdated pkgconfig || brew upgrade pkgconfig
     brew install Caskroom/cask/xquartz
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,9 @@ IF(WANT_STATIC_LIBS AND "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
 ENDIF()
 
 ## Compiler flags, CPACK configuration and other Apple specific code.
-IF(APPLE)
-	include(${PROJECT_SOURCE_DIR}/mk/macos/CMakeLists.txt)
-ENDIF(APPLE)
+# IF(APPLE)
+#	 include(${PROJECT_SOURCE_DIR}/mk/macos/CMakeLists.txt)
+# ENDIF(APPLE)
 
 IF(CMAKE_COMPILER_IS_GNUCXX OR MINGW)
 	IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/source/glest_game/CMakeLists.txt
+++ b/source/glest_game/CMakeLists.txt
@@ -86,6 +86,7 @@ IF(BUILD_ZETAGLEST)
 	ENDIF()
 
 	IF(WANT_USE_OpenSSL)
+		INCLUDE_DIRECTORIES(/usr/local/opt/openssl)
 		set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
 		include(FindOpenSSL)
 		IF(OPENSSL_FOUND)

--- a/source/shared_lib/CMakeLists.txt
+++ b/source/shared_lib/CMakeLists.txt
@@ -81,6 +81,7 @@ IF(BUILD_MODEL_VIEWER OR BUILD_MAP_EDITOR OR BUILD_ZETAGLEST)
 	ENDIF()
 
 	IF(WANT_USE_OpenSSL)
+		INCLUDE_DIRECTORIES(/usr/local/opt/openssl)
 		set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
 		include(FindOpenSSL)
 		IF(OPENSSL_FOUND)


### PR DESCRIPTION
I'm not so sure the CMakeLists.txt in mk/osx is needed. When I disable it, travis is still able to complete the build.

I also added fontconfig to the osx dependencies so cmake could actually find it.

ping #263 